### PR TITLE
Add custom payload

### DIFF
--- a/transport/response.hh
+++ b/transport/response.hh
@@ -66,6 +66,14 @@ public:
         }
     }
 
+    response(int16_t stream, cql_binary_opcode opcode, const tracing::trace_state_ptr& tr_state_ptr,
+             const std::map<sstring, bytes>& custom_payload)
+            : response(stream, opcode, tr_state_ptr)
+    {
+        write_bytes_map(custom_payload);
+        set_frame_flag(cql_frame_flags::custom_payload);
+    }
+
     void set_frame_flag(cql_frame_flags flag) noexcept {
         _flags |= flag;
     }
@@ -82,6 +90,7 @@ public:
     void write_string_list(std::vector<sstring> string_list);
     void write_bytes(bytes b);
     void write_short_bytes(bytes b);
+    void write_bytes_map(const std::map<sstring, bytes>& bytes_map);
     void write_inet(socket_address inet);
     void write_consistency(db::consistency_level c);
     void write_string_map(std::map<sstring, sstring> string_map);

--- a/transport/server.cc
+++ b/transport/server.cc
@@ -1693,6 +1693,15 @@ void cql_server::response::write_short_bytes(bytes b)
     _body.write(b);
 }
 
+void cql_server::response::write_bytes_map(const std::map<sstring, bytes>& bytes_map)
+{
+    write_short(cast_if_fits<uint16_t>(bytes_map.size()));
+    for (auto&& s : bytes_map) {
+        write_string(s.first);
+        write_bytes(s.second);
+    }
+}
+
 void cql_server::response::write_inet(socket_address inet)
 {
     auto addr = inet.addr();

--- a/transport/server.hh
+++ b/transport/server.hh
@@ -82,9 +82,10 @@ enum class cql_compression {
 };
 
 enum cql_frame_flags {
-    compression = 0x01,
-    tracing     = 0x02,
-    warning     = 0x08,
+    compression    = 0x01,
+    tracing        = 0x02,
+    custom_payload = 0x04,
+    warning        = 0x08,
 };
 
 struct [[gnu::packed]] cql_binary_frame_v1 {


### PR DESCRIPTION
transport: add support for setting custom payload
A custom payload can now be passed to the
response constructor. If it is set, it will be sent to
client and the custom_payload flag will be set.

write_bytes_map method is added to response class
and a missing custom_payload flag is added to
cql_frame_flags.