### PR TITLE
tracing: add OpenTelementry trace state to trace_state_ptr

### DIFF
--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -5249,7 +5249,7 @@ void storage_proxy::init_messaging_service(shared_ptr<migration_manager> mm) {
             });
         });
 
-        if (tr_state) {
+        if (tr_state.has_tracing()) {
             f = f.finally([tr_state, src_ip] {
                 tracing::trace(tr_state, "paxos_accept: handling is done, sending a response to /{}", src_ip);
             });

--- a/sstables/index_reader.hh
+++ b/sstables/index_reader.hh
@@ -316,7 +316,7 @@ inline file make_tracked_index_file(sstable& sst, reader_permit permit, tracing:
                                     use_caching caching) {
     auto f = caching ? sst.index_file() : sst.uncached_index_file();
     f = make_tracked_file(std::move(f), std::move(permit));
-    if (!trace_state) {
+    if (!trace_state.has_tracing()) {
         return f;
     }
     return tracing::make_traced_file(std::move(f), std::move(trace_state), format("{}:", sst.filename(component_type::Index)));

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -2286,7 +2286,7 @@ input_stream<char> sstable::data_stream(uint64_t pos, size_t len, const io_prior
     options.dynamic_adjustments = std::move(history);
 
     file f = make_tracked_file(_data_file, std::move(permit));
-    if (trace_state) {
+    if (trace_state.has_tracing()) {
         f = tracing::make_traced_file(std::move(f), std::move(trace_state), format("{}:", get_filename()));
     }
 

--- a/test/boost/tracing.cc
+++ b/test/boost/tracing.cc
@@ -66,7 +66,7 @@ SEASTAR_TEST_CASE(tracing_respect_events) {
         tracing::begin(trace_state1, "begin", gms::inet_address());
 
         tracing::trace(trace_state1, "trace 1");
-        BOOST_CHECK_EQUAL(trace_state1->events_size(), 1);
+        BOOST_CHECK_EQUAL(trace_state1.get_tracing_ptr()->events_size(), 1);
         BOOST_CHECK(tracing::make_trace_info(trace_state1) != std::nullopt);
 
         // disable tracing events, it must be ignored for full tracing
@@ -77,7 +77,7 @@ SEASTAR_TEST_CASE(tracing_respect_events) {
         tracing::begin(trace_state2, "begin", gms::inet_address());
 
         tracing::trace(trace_state2, "trace 1");
-        BOOST_CHECK_EQUAL(trace_state2->events_size(), 1);
+        BOOST_CHECK_EQUAL(trace_state2.get_tracing_ptr()->events_size(), 1);
         BOOST_CHECK(tracing::make_trace_info(trace_state2) != std::nullopt);
 
         return make_ready_future<>();
@@ -101,7 +101,7 @@ SEASTAR_TEST_CASE(tracing_slow_query_fast_mode) {
 
         // check no event created
         tracing::trace(trace_state, "trace 1");
-        BOOST_CHECK_EQUAL(trace_state->events_size(), 0);
+        BOOST_CHECK_EQUAL(trace_state.get_tracing_ptr()->events_size(), 0);
         BOOST_CHECK(tracing::make_trace_info(trace_state) == std::nullopt);
 
         return make_ready_future<>();

--- a/transport/response.hh
+++ b/transport/response.hh
@@ -61,7 +61,7 @@ public:
     {
         if (tracing::should_return_id_in_response(tr_state_ptr)) {
             auto i = _body.write_place_holder(utils::UUID::serialized_size());
-            tr_state_ptr->session_id().serialize(i);
+            tr_state_ptr.get_tracing_ptr()->session_id().serialize(i);
             set_frame_flag(cql_frame_flags::tracing);
         }
     }


### PR DESCRIPTION
Add opentelemetry_state pointer to trace_state_ptr.
Move trace_state pointer to opentelemetry_state for best-case scenario optimisation.