### PR TITLE
Opentelemetry transfer choice

### DIFF
--- a/alternator/server.cc
+++ b/alternator/server.cc
@@ -343,7 +343,7 @@ static tracing::trace_state_ptr create_tracing_session(tracing::tracing& tracing
     tracing::trace_state_props_set props;
     props.set<tracing::trace_state_props::full_tracing>();
     props.set_if<tracing::trace_state_props::log_slow_query>(tracing_instance.slow_query_tracing_enabled());
-    return tracing_instance.create_session(tracing::trace_type::QUERY, props);
+    return tracing_instance.create_session(tracing::trace_type::QUERY, props, false);
 }
 
 // truncated_content_view() prints a potentially long chunked_content for

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -5249,7 +5249,7 @@ void storage_proxy::init_messaging_service(shared_ptr<migration_manager> mm) {
             });
         });
 
-        if (tr_state) {
+        if (tr_state.has_tracing()) {
             f = f.finally([tr_state, src_ip] {
                 tracing::trace(tr_state, "paxos_accept: handling is done, sending a response to /{}", src_ip);
             });

--- a/sstables/index_reader.hh
+++ b/sstables/index_reader.hh
@@ -316,7 +316,7 @@ inline file make_tracked_index_file(sstable& sst, reader_permit permit, tracing:
                                     use_caching caching) {
     auto f = caching ? sst.index_file() : sst.uncached_index_file();
     f = make_tracked_file(std::move(f), std::move(permit));
-    if (!trace_state) {
+    if (!trace_state.has_tracing()) {
         return f;
     }
     return tracing::make_traced_file(std::move(f), std::move(trace_state), format("{}:", sst.filename(component_type::Index)));

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -2286,7 +2286,7 @@ input_stream<char> sstable::data_stream(uint64_t pos, size_t len, const io_prior
     options.dynamic_adjustments = std::move(history);
 
     file f = make_tracked_file(_data_file, std::move(permit));
-    if (trace_state) {
+    if (trace_state.has_tracing()) {
         f = tracing::make_traced_file(std::move(f), std::move(trace_state), format("{}:", get_filename()));
     }
 

--- a/test/boost/tracing.cc
+++ b/test/boost/tracing.cc
@@ -66,7 +66,7 @@ SEASTAR_TEST_CASE(tracing_respect_events) {
         tracing::begin(trace_state1, "begin", gms::inet_address());
 
         tracing::trace(trace_state1, "trace 1");
-        BOOST_CHECK_EQUAL(trace_state1->events_size(), 1);
+        BOOST_CHECK_EQUAL(trace_state1.get_tracing_ptr()->events_size(), 1);
         BOOST_CHECK(tracing::make_trace_info(trace_state1) != std::nullopt);
 
         // disable tracing events, it must be ignored for full tracing
@@ -77,7 +77,7 @@ SEASTAR_TEST_CASE(tracing_respect_events) {
         tracing::begin(trace_state2, "begin", gms::inet_address());
 
         tracing::trace(trace_state2, "trace 1");
-        BOOST_CHECK_EQUAL(trace_state2->events_size(), 1);
+        BOOST_CHECK_EQUAL(trace_state2.get_tracing_ptr()->events_size(), 1);
         BOOST_CHECK(tracing::make_trace_info(trace_state2) != std::nullopt);
 
         return make_ready_future<>();
@@ -101,7 +101,7 @@ SEASTAR_TEST_CASE(tracing_slow_query_fast_mode) {
 
         // check no event created
         tracing::trace(trace_state, "trace 1");
-        BOOST_CHECK_EQUAL(trace_state->events_size(), 0);
+        BOOST_CHECK_EQUAL(trace_state.get_tracing_ptr()->events_size(), 0);
         BOOST_CHECK(tracing::make_trace_info(trace_state) == std::nullopt);
 
         return make_ready_future<>();

--- a/test/boost/tracing.cc
+++ b/test/boost/tracing.cc
@@ -62,7 +62,7 @@ SEASTAR_TEST_CASE(tracing_respect_events) {
         trace_props.set(tracing::trace_state_props::log_slow_query);
         trace_props.set(tracing::trace_state_props::full_tracing);
 
-        tracing::trace_state_ptr trace_state1 = t.create_session(tracing::trace_type::QUERY, trace_props);
+        tracing::trace_state_ptr trace_state1 = t.create_session(tracing::trace_type::QUERY, trace_props, false);
         tracing::begin(trace_state1, "begin", gms::inet_address());
 
         tracing::trace(trace_state1, "trace 1");
@@ -73,7 +73,7 @@ SEASTAR_TEST_CASE(tracing_respect_events) {
         t.set_ignore_trace_events(true);
         BOOST_CHECK(t.ignore_trace_events_enabled());
 
-        tracing::trace_state_ptr trace_state2 = t.create_session(tracing::trace_type::QUERY, trace_props);
+        tracing::trace_state_ptr trace_state2 = t.create_session(tracing::trace_type::QUERY, trace_props, false);
         tracing::begin(trace_state2, "begin", gms::inet_address());
 
         tracing::trace(trace_state2, "trace 1");
@@ -96,7 +96,7 @@ SEASTAR_TEST_CASE(tracing_slow_query_fast_mode) {
         tracing::trace_state_props_set trace_props;
         trace_props.set(tracing::trace_state_props::log_slow_query);
 
-        tracing::trace_state_ptr trace_state = t.create_session(tracing::trace_type::QUERY, trace_props);
+        tracing::trace_state_ptr trace_state = t.create_session(tracing::trace_type::QUERY, trace_props, false);
         tracing::begin(trace_state, "begin", gms::inet_address());
 
         // check no event created

--- a/tracing/trace_state.hh
+++ b/tracing/trace_state.hh
@@ -520,6 +520,11 @@ public:
             : _state_ptr(nullptr), _opentelemetry_tracing(opentelemetry_tracing)
     {}
 
+    bytes serialize() const noexcept {
+        bytes serialized{};
+        return serialized;
+    }
+
     /**
      * @return True if OpenTelemetry trace state is stored.
      */

--- a/tracing/trace_state.hh
+++ b/tracing/trace_state.hh
@@ -505,28 +505,113 @@ private:
     friend void stop_foreground_prepared(const trace_state_ptr& state, const cql3::query_options* prepared_options_ptr) noexcept;
 };
 
-class trace_state_ptr final {
+
+class opentelemetry_state final {
 private:
     lw_shared_ptr<trace_state> _state_ptr;
+    bool const _opentelemetry_tracing{false};
+
+public:
+    opentelemetry_state() = default;
+    opentelemetry_state(lw_shared_ptr<trace_state> state_ptr, bool opentelemetry_tracing = false)
+            : _state_ptr(std::move(state_ptr)), _opentelemetry_tracing(opentelemetry_tracing)
+    {}
+    opentelemetry_state(std::nullptr_t, bool opentelemetry_tracing = false)
+            : _state_ptr(nullptr), _opentelemetry_tracing(opentelemetry_tracing)
+    {}
+
+    /**
+     * @return True if OpenTelemetry trace state is stored.
+     */
+    bool has_opentelemetry() const noexcept {
+        return _opentelemetry_tracing;
+    };
+
+    /**
+     * @return True if classic trace state is stored.
+     */
+    bool has_tracing() const noexcept {
+        return __builtin_expect(bool(_state_ptr), false);
+    };
+
+    /**
+     * @return A pointer to classic trace state.
+     */
+    trace_state* get_tracing_ptr() const noexcept {
+        return _state_ptr.get();
+    }
+
+    /**
+     * @return A reference to classic trace state.
+     */
+    trace_state& get_tracing() const noexcept {
+        return *_state_ptr;
+    }
+};
+
+
+class trace_state_ptr final {
+private:
+    lw_shared_ptr<opentelemetry_state> _state_ptr;
+
+    /**
+     * @return True if classic or OpenTelemetry trace state is stored.
+     */
+    bool has_any_tracing() const noexcept {
+        return __builtin_expect(bool(_state_ptr), false);
+    }
 
 public:
     trace_state_ptr() = default;
-    trace_state_ptr(lw_shared_ptr<trace_state> state_ptr)
+    trace_state_ptr(lw_shared_ptr<opentelemetry_state> state_ptr)
         : _state_ptr(std::move(state_ptr))
+    {}
+    trace_state_ptr(lw_shared_ptr<trace_state> state_ptr)
+        : _state_ptr(make_lw_shared<opentelemetry_state>(std::move(state_ptr)))
     {}
     trace_state_ptr(std::nullptr_t)
         : _state_ptr(nullptr)
     {}
 
-    explicit operator bool() const noexcept {
-        return __builtin_expect(bool(_state_ptr), false);
+    /**
+     * @return True if classic trace state is stored.
+     */
+    bool has_tracing() const noexcept {
+        return __builtin_expect(has_any_tracing() && _state_ptr->has_tracing(), false);
+    };
+
+    /**
+     * @return A pointer to classic trace state.
+     */
+    trace_state* get_tracing_ptr() const noexcept {
+        return _state_ptr->get_tracing_ptr();
     }
 
-    trace_state* operator->() const noexcept {
+    /**
+     * @return A reference to classic trace state.
+     */
+    trace_state& get_tracing() const noexcept {
+        return _state_ptr->get_tracing();
+    }
+
+    /**
+     * @return True if OpenTelemetry trace state is stored.
+     */
+    bool has_opentelemetry() const noexcept {
+        return __builtin_expect(has_any_tracing() && _state_ptr->has_opentelemetry(), false);
+    };
+
+    /**
+     * @return A pointer to OpenTelemetry trace state.
+     */
+    opentelemetry_state* get_opentelemetry_ptr() const noexcept {
         return _state_ptr.get();
     }
 
-    trace_state& operator*() const noexcept {
+    /**
+     * @return A reference to OpenTelemetry trace state.
+     */
+    opentelemetry_state& get_opentelemetry() const noexcept {
         return *_state_ptr;
     }
 };
@@ -596,80 +681,80 @@ inline elapsed_clock::duration trace_state::elapsed() {
 }
 
 inline void set_page_size(const trace_state_ptr& p, int32_t val) {
-    if (p) {
-        p->set_page_size(val);
+    if (p.has_tracing()) {
+        p.get_tracing_ptr()->set_page_size(val);
     }
 }
 
 inline void set_request_size(const trace_state_ptr& p, size_t s) noexcept {
-    if (p) {
-        p->set_request_size(s);
+    if (p.has_tracing()) {
+        p.get_tracing_ptr()->set_request_size(s);
     }
 }
 
 inline void set_response_size(const trace_state_ptr& p, size_t s) noexcept {
-    if (p) {
-        p->set_response_size(s);
+    if (p.has_tracing()) {
+        p.get_tracing_ptr()->set_response_size(s);
     }
 }
 
 inline void set_batchlog_endpoints(const trace_state_ptr& p, const inet_address_vector_replica_set& val) {
-    if (p) {
-        p->set_batchlog_endpoints(val);
+    if (p.has_tracing()) {
+        p.get_tracing_ptr()->set_batchlog_endpoints(val);
     }
 }
 
 inline void set_consistency_level(const trace_state_ptr& p, db::consistency_level val) {
-    if (p) {
-        p->set_consistency_level(val);
+    if (p.has_tracing()) {
+        p.get_tracing_ptr()->set_consistency_level(val);
     }
 }
 
 inline void set_optional_serial_consistency_level(const trace_state_ptr& p, const std::optional<db::consistency_level>& val) {
-    if (p) {
-        p->set_optional_serial_consistency_level(val);
+    if (p.has_tracing()) {
+        p.get_tracing_ptr()->set_optional_serial_consistency_level(val);
     }
 }
 
 inline void add_query(const trace_state_ptr& p, sstring_view val) {
-    if (p) {
-        p->add_query(std::move(val));
+    if (p.has_tracing()) {
+        p.get_tracing_ptr()->add_query(std::move(val));
     }
 }
 
 inline void add_session_param(const trace_state_ptr& p, sstring_view key, sstring_view val) {
-    if (p) {
-        p->add_session_param(std::move(key), std::move(val));
+    if (p.has_tracing()) {
+        p.get_tracing_ptr()->add_session_param(std::move(key), std::move(val));
     }
 }
 
 inline void set_user_timestamp(const trace_state_ptr& p, api::timestamp_type val) {
-    if (p) {
-        p->set_user_timestamp(val);
+    if (p.has_tracing()) {
+        p.get_tracing_ptr()->set_user_timestamp(val);
     }
 }
 
 inline void add_prepared_statement(const trace_state_ptr& p, prepared_checked_weak_ptr& prepared) {
-    if (p) {
-        p->add_prepared_statement(prepared);
+    if (p.has_tracing()) {
+        p.get_tracing_ptr()->add_prepared_statement(prepared);
     }
 }
 
 inline void set_username(const trace_state_ptr& p, const std::optional<auth::authenticated_user>& user) {
-    if (p) {
-        p->set_username(user);
+    if (p.has_tracing()) {
+        p.get_tracing_ptr()->set_username(user);
     }
 }
 
 inline void add_table_name(const trace_state_ptr& p, const sstring& ks_name, const sstring& cf_name) {
-    if (p) {
-        p->add_table_name(ks_name + "." + cf_name);
+    if (p.has_tracing()) {
+        p.get_tracing_ptr()->add_table_name(ks_name + "." + cf_name);
     }
 }
 
 inline bool should_return_id_in_response(const trace_state_ptr& p) {
-    if (p) {
-        return p->write_on_close();
+    if (p.has_tracing()) {
+        return p.get_tracing_ptr()->write_on_close();
     }
     return false;
 }
@@ -686,8 +771,8 @@ inline bool should_return_id_in_response(const trace_state_ptr& p) {
  */
 template <typename... A>
 inline void begin(const trace_state_ptr& p, A&&... a) {
-    if (p) {
-        p->begin(std::forward<A>(a)...);
+    if (p.has_tracing()) {
+        p.get_tracing_ptr()->begin(std::forward<A>(a)...);
     }
 }
 
@@ -711,8 +796,8 @@ inline void begin(const trace_state_ptr& p, A&&... a) {
  */
 template <typename... A>
 inline void trace(const trace_state_ptr& p, A&&... a) noexcept {
-    if (p && !p->ignore_events()) {
-        p->trace(std::forward<A>(a)...);
+    if (p.has_tracing() && !p.get_tracing_ptr()->ignore_events()) {
+        p.get_tracing_ptr()->trace(std::forward<A>(a)...);
     }
 }
 
@@ -724,22 +809,26 @@ inline std::optional<trace_info> make_trace_info(const trace_state_ptr& state) {
     // When only a slow query logging is enabled we don't really care what
     // happens on a remote replica after a Client has received a response for
     // his/her query.
-    if (state && !state->ignore_events() && (state->full_tracing() || (state->log_slow_query() && !state->is_in_state(trace_state::state::background)))) {
-        return trace_info{state->session_id(), state->type(), state->write_on_close(), state->raw_props(), state->slow_query_threshold_us(), state->slow_query_ttl_sec(), state->my_span_id()};
+    if (state.has_tracing()) {
+        const auto& tr_state_ptr = state.get_tracing_ptr();
+
+        if (!tr_state_ptr->ignore_events() && (tr_state_ptr->full_tracing() || (tr_state_ptr->log_slow_query() && !tr_state_ptr->is_in_state(trace_state::state::background)))) {
+            return trace_info{tr_state_ptr->session_id(), tr_state_ptr->type(), tr_state_ptr->write_on_close(), tr_state_ptr->raw_props(), tr_state_ptr->slow_query_threshold_us(), tr_state_ptr->slow_query_ttl_sec(), tr_state_ptr->my_span_id()};
+        }
     }
 
     return std::nullopt;
 }
 
 inline void stop_foreground(const trace_state_ptr& state) noexcept {
-    if (state) {
-        state->stop_foreground_and_write();
+    if (state.has_tracing()) {
+        state.get_tracing_ptr()->stop_foreground_and_write();
     }
 }
 
 inline void add_prepared_query_options(const trace_state_ptr& state, const cql3::query_options& prepared_options_ptr) {
-    if (state) {
-        state->add_prepared_query_options(prepared_options_ptr);
+    if (state.has_tracing()) {
+        state.get_tracing_ptr()->add_prepared_query_options(prepared_options_ptr);
     }
 }
 
@@ -779,7 +868,7 @@ public:
     // May be invoked across shards.
     trace_state_ptr get() const {
         // optimize the "tracing not enabled" case
-        if (!_ptr) {
+        if (!_ptr.has_tracing()) {
             return nullptr;
         }
 

--- a/tracing/tracing.hh
+++ b/tracing/tracing.hh
@@ -485,10 +485,11 @@ public:
      *
      * @param type a tracing session type
      * @param props trace session properties set
+     * @param opentelemetry_tracing flag determining whether OpenTelemetry tracing is required
      *
      * @return tracing state handle
      */
-    trace_state_ptr create_session(trace_type type, trace_state_props_set props) noexcept;
+    trace_state_ptr create_session(trace_type type, trace_state_props_set props, bool opentelemetry_tracing) noexcept;
 
     /**
      * Create a new secondary tracing session.

--- a/transport/cql_protocol_extension.cc
+++ b/transport/cql_protocol_extension.cc
@@ -28,7 +28,8 @@
 namespace cql_transport {
 
 static const std::map<cql_protocol_extension, seastar::sstring> EXTENSION_NAMES = {
-    {cql_protocol_extension::LWT_ADD_METADATA_MARK, "SCYLLA_LWT_ADD_METADATA_MARK"}
+    {cql_protocol_extension::LWT_ADD_METADATA_MARK, "SCYLLA_LWT_ADD_METADATA_MARK"},
+    {cql_protocol_extension::OPENTELEMETRY_TRACING, "SCYLLA_OPENTELEMETRY_TRACING"}
 };
 
 cql_protocol_extension_enum_set supported_cql_protocol_extensions() {

--- a/transport/cql_protocol_extension.hh
+++ b/transport/cql_protocol_extension.hh
@@ -41,11 +41,12 @@ namespace cql_transport {
  * `docs/protocol-extensions.md`. 
  */
 enum class cql_protocol_extension {
-    LWT_ADD_METADATA_MARK
+    LWT_ADD_METADATA_MARK,
+    OPENTELEMETRY_TRACING
 };
 
 using cql_protocol_extension_enum = super_enum<cql_protocol_extension,
-    cql_protocol_extension::LWT_ADD_METADATA_MARK>;
+    cql_protocol_extension::LWT_ADD_METADATA_MARK, cql_protocol_extension::OPENTELEMETRY_TRACING>;
 
 using cql_protocol_extension_enum_set = enum_set<cql_protocol_extension_enum>;
 

--- a/transport/response.hh
+++ b/transport/response.hh
@@ -64,14 +64,12 @@ public:
             tr_state_ptr.get_tracing_ptr()->session_id().serialize(i);
             set_frame_flag(cql_frame_flags::tracing);
         }
-    }
 
-    response(int16_t stream, cql_binary_opcode opcode, const tracing::trace_state_ptr& tr_state_ptr,
-             const std::map<sstring, bytes>& custom_payload)
-            : response(stream, opcode, tr_state_ptr)
-    {
-        write_bytes_map(custom_payload);
-        set_frame_flag(cql_frame_flags::custom_payload);
+        if (tr_state_ptr.has_opentelemetry()) {
+            std::map<sstring, bytes> custom_payload{{"opentelemetry", tr_state_ptr.get_opentelemetry_ptr()->serialize()}};
+            write_bytes_map(custom_payload);
+            set_frame_flag(cql_frame_flags::custom_payload);
+        }
     }
 
     void set_frame_flag(cql_frame_flags flag) noexcept {

--- a/transport/response.hh
+++ b/transport/response.hh
@@ -61,7 +61,7 @@ public:
     {
         if (tracing::should_return_id_in_response(tr_state_ptr)) {
             auto i = _body.write_place_holder(utils::UUID::serialized_size());
-            tr_state_ptr->session_id().serialize(i);
+            tr_state_ptr.get_tracing_ptr()->session_id().serialize(i);
             set_frame_flag(cql_frame_flags::tracing);
         }
     }


### PR DESCRIPTION
Having been fixed after review, the PR now contains 3 commits as follows:
- tracing: add OpenTelementry trace state to trace_state_ptr - puts information about opentelemetry tracing in trace_state_ptr. 
New: OpenTelemetry tracing flag is set in constructors of opentelemetry_state.
- instantiate trace_state_ptr basing on user's tracing choice - basing on the result of negotiation with driver proper fields of trace_state_ptr are set.
- pass content of opentelemetry_state to response - otel tracing info is sent to client iff OpenTelemetry tracing was requested.
New: instead of {"abc", "abc"} a map with serialized tracing data is passed (empty yet though); make_unique_response was moved to tracing/response.hh.

All previous PRs were updated too so partial review/merge could be done.