### PR TITLE
Opentelemetry passing trace state ptr content

### DIFF
--- a/alternator/server.cc
+++ b/alternator/server.cc
@@ -343,7 +343,7 @@ static tracing::trace_state_ptr create_tracing_session(tracing::tracing& tracing
     tracing::trace_state_props_set props;
     props.set<tracing::trace_state_props::full_tracing>();
     props.set_if<tracing::trace_state_props::log_slow_query>(tracing_instance.slow_query_tracing_enabled());
-    return tracing_instance.create_session(tracing::trace_type::QUERY, props);
+    return tracing_instance.create_session(tracing::trace_type::QUERY, props, false);
 }
 
 // truncated_content_view() prints a potentially long chunked_content for

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -1456,6 +1456,10 @@ storage_proxy::response_id_type storage_proxy::create_write_response_handler(key
     shared_ptr<abstract_write_response_handler> h;
     auto& rs = ks.get_replication_strategy();
 
+    if (tr_state.has_opentelemetry()) {
+        tr_state.get_opentelemetry_ptr()->set_replicas(targets);
+    }
+
     if (db::is_datacenter_local(cl)) {
         h = ::make_shared<datacenter_write_response_handler>(shared_from_this(), ks, cl, type, std::move(m), std::move(targets), pending_endpoints, std::move(dead_endpoints), std::move(tr_state), stats, std::move(permit));
     } else if (cl == db::consistency_level::EACH_QUORUM && rs.get_type() == locator::replication_strategy_type::network_topology){

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -5249,7 +5249,7 @@ void storage_proxy::init_messaging_service(shared_ptr<migration_manager> mm) {
             });
         });
 
-        if (tr_state) {
+        if (tr_state.has_tracing()) {
             f = f.finally([tr_state, src_ip] {
                 tracing::trace(tr_state, "paxos_accept: handling is done, sending a response to /{}", src_ip);
             });

--- a/sstables/index_reader.hh
+++ b/sstables/index_reader.hh
@@ -316,7 +316,7 @@ inline file make_tracked_index_file(sstable& sst, reader_permit permit, tracing:
                                     use_caching caching) {
     auto f = caching ? sst.index_file() : sst.uncached_index_file();
     f = make_tracked_file(std::move(f), std::move(permit));
-    if (!trace_state) {
+    if (!trace_state.has_tracing()) {
         return f;
     }
     return tracing::make_traced_file(std::move(f), std::move(trace_state), format("{}:", sst.filename(component_type::Index)));

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -2286,7 +2286,7 @@ input_stream<char> sstable::data_stream(uint64_t pos, size_t len, const io_prior
     options.dynamic_adjustments = std::move(history);
 
     file f = make_tracked_file(_data_file, std::move(permit));
-    if (trace_state) {
+    if (trace_state.has_tracing()) {
         f = tracing::make_traced_file(std::move(f), std::move(trace_state), format("{}:", get_filename()));
     }
 

--- a/test/boost/tracing.cc
+++ b/test/boost/tracing.cc
@@ -66,7 +66,7 @@ SEASTAR_TEST_CASE(tracing_respect_events) {
         tracing::begin(trace_state1, "begin", gms::inet_address());
 
         tracing::trace(trace_state1, "trace 1");
-        BOOST_CHECK_EQUAL(trace_state1->events_size(), 1);
+        BOOST_CHECK_EQUAL(trace_state1.get_tracing_ptr()->events_size(), 1);
         BOOST_CHECK(tracing::make_trace_info(trace_state1) != std::nullopt);
 
         // disable tracing events, it must be ignored for full tracing
@@ -77,7 +77,7 @@ SEASTAR_TEST_CASE(tracing_respect_events) {
         tracing::begin(trace_state2, "begin", gms::inet_address());
 
         tracing::trace(trace_state2, "trace 1");
-        BOOST_CHECK_EQUAL(trace_state2->events_size(), 1);
+        BOOST_CHECK_EQUAL(trace_state2.get_tracing_ptr()->events_size(), 1);
         BOOST_CHECK(tracing::make_trace_info(trace_state2) != std::nullopt);
 
         return make_ready_future<>();
@@ -101,7 +101,7 @@ SEASTAR_TEST_CASE(tracing_slow_query_fast_mode) {
 
         // check no event created
         tracing::trace(trace_state, "trace 1");
-        BOOST_CHECK_EQUAL(trace_state->events_size(), 0);
+        BOOST_CHECK_EQUAL(trace_state.get_tracing_ptr()->events_size(), 0);
         BOOST_CHECK(tracing::make_trace_info(trace_state) == std::nullopt);
 
         return make_ready_future<>();

--- a/test/boost/tracing.cc
+++ b/test/boost/tracing.cc
@@ -62,7 +62,7 @@ SEASTAR_TEST_CASE(tracing_respect_events) {
         trace_props.set(tracing::trace_state_props::log_slow_query);
         trace_props.set(tracing::trace_state_props::full_tracing);
 
-        tracing::trace_state_ptr trace_state1 = t.create_session(tracing::trace_type::QUERY, trace_props);
+        tracing::trace_state_ptr trace_state1 = t.create_session(tracing::trace_type::QUERY, trace_props, false);
         tracing::begin(trace_state1, "begin", gms::inet_address());
 
         tracing::trace(trace_state1, "trace 1");
@@ -73,7 +73,7 @@ SEASTAR_TEST_CASE(tracing_respect_events) {
         t.set_ignore_trace_events(true);
         BOOST_CHECK(t.ignore_trace_events_enabled());
 
-        tracing::trace_state_ptr trace_state2 = t.create_session(tracing::trace_type::QUERY, trace_props);
+        tracing::trace_state_ptr trace_state2 = t.create_session(tracing::trace_type::QUERY, trace_props, false);
         tracing::begin(trace_state2, "begin", gms::inet_address());
 
         tracing::trace(trace_state2, "trace 1");
@@ -96,7 +96,7 @@ SEASTAR_TEST_CASE(tracing_slow_query_fast_mode) {
         tracing::trace_state_props_set trace_props;
         trace_props.set(tracing::trace_state_props::log_slow_query);
 
-        tracing::trace_state_ptr trace_state = t.create_session(tracing::trace_type::QUERY, trace_props);
+        tracing::trace_state_ptr trace_state = t.create_session(tracing::trace_type::QUERY, trace_props, false);
         tracing::begin(trace_state, "begin", gms::inet_address());
 
         // check no event created

--- a/tracing/trace_state.hh
+++ b/tracing/trace_state.hh
@@ -505,28 +505,113 @@ private:
     friend void stop_foreground_prepared(const trace_state_ptr& state, const cql3::query_options* prepared_options_ptr) noexcept;
 };
 
-class trace_state_ptr final {
+
+class opentelemetry_state final {
 private:
     lw_shared_ptr<trace_state> _state_ptr;
+    bool const _opentelemetry_tracing{false};
+
+public:
+    opentelemetry_state() = default;
+    opentelemetry_state(lw_shared_ptr<trace_state> state_ptr)
+        : _state_ptr(std::move(state_ptr))
+    {}
+    opentelemetry_state(std::nullptr_t)
+        : _state_ptr(nullptr)
+    {}
+
+    /**
+     * @return True if OpenTelemetry trace state is stored.
+     */
+    bool has_opentelemetry() const noexcept {
+        return _opentelemetry_tracing;
+    };
+
+    /**
+     * @return True if classic trace state is stored.
+     */
+    bool has_tracing() const noexcept {
+        return bool(_state_ptr);
+    };
+
+    /**
+     * @return A pointer to classic trace state.
+     */
+    trace_state* get_tracing_ptr() const noexcept {
+        return _state_ptr.get();
+    }
+
+    /**
+     * @return A reference to classic trace state.
+     */
+    trace_state& get_tracing() const noexcept {
+        return *_state_ptr;
+    }
+};
+
+
+class trace_state_ptr final {
+private:
+    lw_shared_ptr<opentelemetry_state> _state_ptr;
+
+    /**
+     * @return True if classic or OpenTelemetry trace state is stored.
+     */
+    bool has_any_tracing() const noexcept {
+        return __builtin_expect(bool(_state_ptr), false);
+    }
 
 public:
     trace_state_ptr() = default;
-    trace_state_ptr(lw_shared_ptr<trace_state> state_ptr)
+    trace_state_ptr(lw_shared_ptr<opentelemetry_state> state_ptr)
         : _state_ptr(std::move(state_ptr))
+    {}
+    trace_state_ptr(lw_shared_ptr<trace_state> state_ptr)
+        : _state_ptr(make_lw_shared<opentelemetry_state>(std::move(state_ptr)))
     {}
     trace_state_ptr(std::nullptr_t)
         : _state_ptr(nullptr)
     {}
 
-    explicit operator bool() const noexcept {
-        return __builtin_expect(bool(_state_ptr), false);
+    /**
+     * @return True if classic trace state is stored.
+     */
+    bool has_tracing() const noexcept {
+        return has_any_tracing() && _state_ptr->has_tracing();
+    };
+
+    /**
+     * @return A pointer to classic trace state.
+     */
+    trace_state* get_tracing_ptr() const noexcept {
+        return _state_ptr->get_tracing_ptr();
     }
 
-    trace_state* operator->() const noexcept {
+    /**
+     * @return A reference to classic trace state.
+     */
+    trace_state& get_tracing() const noexcept {
+        return _state_ptr->get_tracing();
+    }
+
+    /**
+     * @return True if OpenTelemetry trace state is stored.
+     */
+    bool has_opentelemetry() const noexcept {
+        return has_any_tracing() && _state_ptr->has_opentelemetry();
+    };
+
+    /**
+     * @return A pointer to OpenTelemetry trace state.
+     */
+    opentelemetry_state* get_opentelemetry_ptr() const noexcept {
         return _state_ptr.get();
     }
 
-    trace_state& operator*() const noexcept {
+    /**
+     * @return A reference to OpenTelemetry trace state.
+     */
+    opentelemetry_state& get_opentelemetry() const noexcept {
         return *_state_ptr;
     }
 };
@@ -596,80 +681,80 @@ inline elapsed_clock::duration trace_state::elapsed() {
 }
 
 inline void set_page_size(const trace_state_ptr& p, int32_t val) {
-    if (p) {
-        p->set_page_size(val);
+    if (p.has_tracing()) {
+        p.get_tracing_ptr()->set_page_size(val);
     }
 }
 
 inline void set_request_size(const trace_state_ptr& p, size_t s) noexcept {
-    if (p) {
-        p->set_request_size(s);
+    if (p.has_tracing()) {
+        p.get_tracing_ptr()->set_request_size(s);
     }
 }
 
 inline void set_response_size(const trace_state_ptr& p, size_t s) noexcept {
-    if (p) {
-        p->set_response_size(s);
+    if (p.has_tracing()) {
+        p.get_tracing_ptr()->set_response_size(s);
     }
 }
 
 inline void set_batchlog_endpoints(const trace_state_ptr& p, const inet_address_vector_replica_set& val) {
-    if (p) {
-        p->set_batchlog_endpoints(val);
+    if (p.has_tracing()) {
+        p.get_tracing_ptr()->set_batchlog_endpoints(val);
     }
 }
 
 inline void set_consistency_level(const trace_state_ptr& p, db::consistency_level val) {
-    if (p) {
-        p->set_consistency_level(val);
+    if (p.has_tracing()) {
+        p.get_tracing_ptr()->set_consistency_level(val);
     }
 }
 
 inline void set_optional_serial_consistency_level(const trace_state_ptr& p, const std::optional<db::consistency_level>& val) {
-    if (p) {
-        p->set_optional_serial_consistency_level(val);
+    if (p.has_tracing()) {
+        p.get_tracing_ptr()->set_optional_serial_consistency_level(val);
     }
 }
 
 inline void add_query(const trace_state_ptr& p, sstring_view val) {
-    if (p) {
-        p->add_query(std::move(val));
+    if (p.has_tracing()) {
+        p.get_tracing_ptr()->add_query(std::move(val));
     }
 }
 
 inline void add_session_param(const trace_state_ptr& p, sstring_view key, sstring_view val) {
-    if (p) {
-        p->add_session_param(std::move(key), std::move(val));
+    if (p.has_tracing()) {
+        p.get_tracing_ptr()->add_session_param(std::move(key), std::move(val));
     }
 }
 
 inline void set_user_timestamp(const trace_state_ptr& p, api::timestamp_type val) {
-    if (p) {
-        p->set_user_timestamp(val);
+    if (p.has_tracing()) {
+        p.get_tracing_ptr()->set_user_timestamp(val);
     }
 }
 
 inline void add_prepared_statement(const trace_state_ptr& p, prepared_checked_weak_ptr& prepared) {
-    if (p) {
-        p->add_prepared_statement(prepared);
+    if (p.has_tracing()) {
+        p.get_tracing_ptr()->add_prepared_statement(prepared);
     }
 }
 
 inline void set_username(const trace_state_ptr& p, const std::optional<auth::authenticated_user>& user) {
-    if (p) {
-        p->set_username(user);
+    if (p.has_tracing()) {
+        p.get_tracing_ptr()->set_username(user);
     }
 }
 
 inline void add_table_name(const trace_state_ptr& p, const sstring& ks_name, const sstring& cf_name) {
-    if (p) {
-        p->add_table_name(ks_name + "." + cf_name);
+    if (p.has_tracing()) {
+        p.get_tracing_ptr()->add_table_name(ks_name + "." + cf_name);
     }
 }
 
 inline bool should_return_id_in_response(const trace_state_ptr& p) {
-    if (p) {
-        return p->write_on_close();
+    if (p.has_tracing()) {
+        return p.get_tracing_ptr()->write_on_close();
     }
     return false;
 }
@@ -686,8 +771,8 @@ inline bool should_return_id_in_response(const trace_state_ptr& p) {
  */
 template <typename... A>
 inline void begin(const trace_state_ptr& p, A&&... a) {
-    if (p) {
-        p->begin(std::forward<A>(a)...);
+    if (p.has_tracing()) {
+        p.get_tracing_ptr()->begin(std::forward<A>(a)...);
     }
 }
 
@@ -711,8 +796,8 @@ inline void begin(const trace_state_ptr& p, A&&... a) {
  */
 template <typename... A>
 inline void trace(const trace_state_ptr& p, A&&... a) noexcept {
-    if (p && !p->ignore_events()) {
-        p->trace(std::forward<A>(a)...);
+    if (p.has_tracing() && !p.get_tracing_ptr()->ignore_events()) {
+        p.get_tracing_ptr()->trace(std::forward<A>(a)...);
     }
 }
 
@@ -724,22 +809,26 @@ inline std::optional<trace_info> make_trace_info(const trace_state_ptr& state) {
     // When only a slow query logging is enabled we don't really care what
     // happens on a remote replica after a Client has received a response for
     // his/her query.
-    if (state && !state->ignore_events() && (state->full_tracing() || (state->log_slow_query() && !state->is_in_state(trace_state::state::background)))) {
-        return trace_info{state->session_id(), state->type(), state->write_on_close(), state->raw_props(), state->slow_query_threshold_us(), state->slow_query_ttl_sec(), state->my_span_id()};
+    if (state.has_tracing()) {
+        const auto& tr_state_ptr = state.get_tracing_ptr();
+
+        if (!tr_state_ptr->ignore_events() && (tr_state_ptr->full_tracing() || (tr_state_ptr->log_slow_query() && !tr_state_ptr->is_in_state(trace_state::state::background)))) {
+            return trace_info{tr_state_ptr->session_id(), tr_state_ptr->type(), tr_state_ptr->write_on_close(), tr_state_ptr->raw_props(), tr_state_ptr->slow_query_threshold_us(), tr_state_ptr->slow_query_ttl_sec(), tr_state_ptr->my_span_id()};
+        }
     }
 
     return std::nullopt;
 }
 
 inline void stop_foreground(const trace_state_ptr& state) noexcept {
-    if (state) {
-        state->stop_foreground_and_write();
+    if (state.has_tracing()) {
+        state.get_tracing_ptr()->stop_foreground_and_write();
     }
 }
 
 inline void add_prepared_query_options(const trace_state_ptr& state, const cql3::query_options& prepared_options_ptr) {
-    if (state) {
-        state->add_prepared_query_options(prepared_options_ptr);
+    if (state.has_tracing()) {
+        state.get_tracing_ptr()->add_prepared_query_options(prepared_options_ptr);
     }
 }
 
@@ -779,7 +868,7 @@ public:
     // May be invoked across shards.
     trace_state_ptr get() const {
         // optimize the "tracing not enabled" case
-        if (!_ptr) {
+        if (!_ptr.has_tracing()) {
             return nullptr;
         }
 

--- a/tracing/trace_state.hh
+++ b/tracing/trace_state.hh
@@ -513,11 +513,11 @@ private:
 
 public:
     opentelemetry_state() = default;
-    opentelemetry_state(lw_shared_ptr<trace_state> state_ptr)
-        : _state_ptr(std::move(state_ptr))
+    opentelemetry_state(lw_shared_ptr<trace_state> state_ptr, bool opentelemetry_tracing = false)
+        : _state_ptr(std::move(state_ptr)), _opentelemetry_tracing(opentelemetry_tracing)
     {}
-    opentelemetry_state(std::nullptr_t)
-        : _state_ptr(nullptr)
+    opentelemetry_state(std::nullptr_t, bool opentelemetry_tracing = false)
+        : _state_ptr(nullptr), _opentelemetry_tracing(opentelemetry_tracing)
     {}
 
     /**

--- a/tracing/tracing.cc
+++ b/tracing/tracing.cc
@@ -115,7 +115,7 @@ future<> tracing::stop_tracing() {
     });
 }
 
-trace_state_ptr tracing::create_session(trace_type type, trace_state_props_set props) noexcept {
+trace_state_ptr tracing::create_session(trace_type type, trace_state_props_set props, bool opentelemetry_tracing) noexcept {
     if (!started()) {
         return nullptr;
     }
@@ -130,7 +130,7 @@ trace_state_ptr tracing::create_session(trace_type type, trace_state_props_set p
         props.set_if<trace_state_props::ignore_events>(!props.contains<trace_state_props::full_tracing>() && ignore_trace_events_enabled());
 
         ++_active_sessions;
-        return make_lw_shared<trace_state>(type, props);
+        return make_lw_shared<opentelemetry_state>(make_lw_shared<trace_state>(type, props), opentelemetry_tracing);
     } catch (...) {
         // return an uninitialized state in case of any error (OOM?)
         return nullptr;
@@ -149,7 +149,7 @@ trace_state_ptr tracing::create_session(const trace_info& secondary_session_info
         }
 
         ++_active_sessions;
-        return make_lw_shared<trace_state>(secondary_session_info);
+        return make_lw_shared<opentelemetry_state>(make_lw_shared<trace_state>(secondary_session_info));
     } catch (...) {
         // return an uninitialized state in case of any error (OOM?)
         return nullptr;

--- a/tracing/tracing.hh
+++ b/tracing/tracing.hh
@@ -485,10 +485,11 @@ public:
      *
      * @param type a tracing session type
      * @param props trace session properties set
+     * @param opentelemetry_tracing flag determining whether OpenTelemetry tracing is required
      *
      * @return tracing state handle
      */
-    trace_state_ptr create_session(trace_type type, trace_state_props_set props) noexcept;
+    trace_state_ptr create_session(trace_type type, trace_state_props_set props, bool opentelemetry_tracing) noexcept;
 
     /**
      * Create a new secondary tracing session.

--- a/transport/cql_protocol_extension.cc
+++ b/transport/cql_protocol_extension.cc
@@ -28,7 +28,8 @@
 namespace cql_transport {
 
 static const std::map<cql_protocol_extension, seastar::sstring> EXTENSION_NAMES = {
-    {cql_protocol_extension::LWT_ADD_METADATA_MARK, "SCYLLA_LWT_ADD_METADATA_MARK"}
+    {cql_protocol_extension::LWT_ADD_METADATA_MARK, "SCYLLA_LWT_ADD_METADATA_MARK"},
+    {cql_protocol_extension::OPENTELEMETRY_TRACING, "SCYLLA_OPENTELEMETRY_TRACING"}
 };
 
 cql_protocol_extension_enum_set supported_cql_protocol_extensions() {

--- a/transport/cql_protocol_extension.hh
+++ b/transport/cql_protocol_extension.hh
@@ -41,11 +41,12 @@ namespace cql_transport {
  * `docs/protocol-extensions.md`. 
  */
 enum class cql_protocol_extension {
-    LWT_ADD_METADATA_MARK
+    LWT_ADD_METADATA_MARK,
+    OPENTELEMETRY_TRACING
 };
 
 using cql_protocol_extension_enum = super_enum<cql_protocol_extension,
-    cql_protocol_extension::LWT_ADD_METADATA_MARK>;
+    cql_protocol_extension::LWT_ADD_METADATA_MARK, cql_protocol_extension::OPENTELEMETRY_TRACING>;
 
 using cql_protocol_extension_enum_set = enum_set<cql_protocol_extension_enum>;
 

--- a/transport/response.hh
+++ b/transport/response.hh
@@ -61,7 +61,7 @@ public:
     {
         if (tracing::should_return_id_in_response(tr_state_ptr)) {
             auto i = _body.write_place_holder(utils::UUID::serialized_size());
-            tr_state_ptr->session_id().serialize(i);
+            tr_state_ptr.get_tracing_ptr()->session_id().serialize(i);
             set_frame_flag(cql_frame_flags::tracing);
         }
     }

--- a/transport/server.cc
+++ b/transport/server.cc
@@ -1209,9 +1209,19 @@ cql_server::connection::process_register(uint16_t stream, request_reader in, ser
     });
 }
 
+inline std::unique_ptr<cql_server::response> create_proper_response(bool tracing_required, int16_t stream, cql_binary_opcode opcode, const tracing::trace_state_ptr& tr_state_ptr) {
+    if (tracing_required) {
+        std::map<sstring, bytes> m{{"open_telemetry", tr_state_ptr.serialize()}};
+        return std::make_unique<cql_server::response>(stream, opcode, tr_state_ptr, m);
+    }
+    else {
+        return std::make_unique<cql_server::response>(stream, opcode, tr_state_ptr);
+    }
+}
+
 std::unique_ptr<cql_server::response> cql_server::connection::make_unavailable_error(int16_t stream, exceptions::exception_code err, sstring msg, db::consistency_level cl, int32_t required, int32_t alive, const tracing::trace_state_ptr& tr_state) const
 {
-    auto response = std::make_unique<cql_server::response>(stream, cql_binary_opcode::ERROR, tr_state);
+    auto response = create_proper_response(_server._query_processor.local().is_tracing_required(), stream, cql_binary_opcode::ERROR, tr_state);
     response->write_int(static_cast<int32_t>(err));
     response->write_string(msg);
     response->write_consistency(cl);
@@ -1222,7 +1232,7 @@ std::unique_ptr<cql_server::response> cql_server::connection::make_unavailable_e
 
 std::unique_ptr<cql_server::response> cql_server::connection::make_read_timeout_error(int16_t stream, exceptions::exception_code err, sstring msg, db::consistency_level cl, int32_t received, int32_t blockfor, bool data_present, const tracing::trace_state_ptr& tr_state) const
 {
-    auto response = std::make_unique<cql_server::response>(stream, cql_binary_opcode::ERROR, tr_state);
+    auto response = create_proper_response(_server._query_processor.local().is_tracing_required(), stream, cql_binary_opcode::ERROR, tr_state);
     response->write_int(static_cast<int32_t>(err));
     response->write_string(msg);
     response->write_consistency(cl);
@@ -1237,7 +1247,7 @@ std::unique_ptr<cql_server::response> cql_server::connection::make_read_failure_
     if (_version < 4) {
         return make_read_timeout_error(stream, err, std::move(msg), cl, received, blockfor, data_present, tr_state);
     }
-    auto response = std::make_unique<cql_server::response>(stream, cql_binary_opcode::ERROR, tr_state);
+    auto response = create_proper_response(_server._query_processor.local().is_tracing_required(), stream, cql_binary_opcode::ERROR, tr_state);
     response->write_int(static_cast<int32_t>(err));
     response->write_string(msg);
     response->write_consistency(cl);
@@ -1250,7 +1260,7 @@ std::unique_ptr<cql_server::response> cql_server::connection::make_read_failure_
 
 std::unique_ptr<cql_server::response> cql_server::connection::make_mutation_write_timeout_error(int16_t stream, exceptions::exception_code err, sstring msg, db::consistency_level cl, int32_t received, int32_t blockfor, db::write_type type, const tracing::trace_state_ptr& tr_state) const
 {
-    auto response = std::make_unique<cql_server::response>(stream, cql_binary_opcode::ERROR, tr_state);
+    auto response = create_proper_response(_server._query_processor.local().is_tracing_required(), stream, cql_binary_opcode::ERROR, tr_state);
     response->write_int(static_cast<int32_t>(err));
     response->write_string(msg);
     response->write_consistency(cl);
@@ -1265,7 +1275,7 @@ std::unique_ptr<cql_server::response> cql_server::connection::make_mutation_writ
     if (_version < 4) {
         return make_mutation_write_timeout_error(stream, err, std::move(msg), cl, received, blockfor, type, tr_state);
     }
-    auto response = std::make_unique<cql_server::response>(stream, cql_binary_opcode::ERROR, tr_state);
+    auto response = create_proper_response(_server._query_processor.local().is_tracing_required(), stream, cql_binary_opcode::ERROR, tr_state);
     response->write_int(static_cast<int32_t>(err));
     response->write_string(msg);
     response->write_consistency(cl);
@@ -1278,7 +1288,7 @@ std::unique_ptr<cql_server::response> cql_server::connection::make_mutation_writ
 
 std::unique_ptr<cql_server::response> cql_server::connection::make_already_exists_error(int16_t stream, exceptions::exception_code err, sstring msg, sstring ks_name, sstring cf_name, const tracing::trace_state_ptr& tr_state) const
 {
-    auto response = std::make_unique<cql_server::response>(stream, cql_binary_opcode::ERROR, tr_state);
+    auto response = create_proper_response(_server._query_processor.local().is_tracing_required(), stream, cql_binary_opcode::ERROR, tr_state);
     response->write_int(static_cast<int32_t>(err));
     response->write_string(msg);
     response->write_string(ks_name);
@@ -1288,7 +1298,7 @@ std::unique_ptr<cql_server::response> cql_server::connection::make_already_exist
 
 std::unique_ptr<cql_server::response> cql_server::connection::make_unprepared_error(int16_t stream, exceptions::exception_code err, sstring msg, bytes id, const tracing::trace_state_ptr& tr_state) const
 {
-    auto response = std::make_unique<cql_server::response>(stream, cql_binary_opcode::ERROR, tr_state);
+    auto response = create_proper_response(_server._query_processor.local().is_tracing_required(), stream, cql_binary_opcode::ERROR, tr_state);
     response->write_int(static_cast<int32_t>(err));
     response->write_string(msg);
     response->write_short_bytes(id);
@@ -1297,7 +1307,7 @@ std::unique_ptr<cql_server::response> cql_server::connection::make_unprepared_er
 
 std::unique_ptr<cql_server::response> cql_server::connection::make_function_failure_error(int16_t stream, exceptions::exception_code err, sstring msg, sstring ks_name, sstring func_name, std::vector<sstring> args, const tracing::trace_state_ptr& tr_state) const
 {
-    auto response = std::make_unique<cql_server::response>(stream, cql_binary_opcode::ERROR, tr_state);
+    auto response = create_proper_response(_server._query_processor.local().is_tracing_required(), stream, cql_binary_opcode::ERROR, tr_state);
     response->write_int(static_cast<int32_t>(err));
     response->write_string(msg);
     response->write_string(ks_name);
@@ -1308,7 +1318,7 @@ std::unique_ptr<cql_server::response> cql_server::connection::make_function_fail
 
 std::unique_ptr<cql_server::response> cql_server::connection::make_error(int16_t stream, exceptions::exception_code err, sstring msg, const tracing::trace_state_ptr& tr_state) const
 {
-    auto response = std::make_unique<cql_server::response>(stream, cql_binary_opcode::ERROR, tr_state);
+    auto response = create_proper_response(_server._query_processor.local().is_tracing_required(), stream, cql_binary_opcode::ERROR, tr_state);
     response->write_int(static_cast<int32_t>(err));
     response->write_string(msg);
     return response;
@@ -1316,24 +1326,24 @@ std::unique_ptr<cql_server::response> cql_server::connection::make_error(int16_t
 
 std::unique_ptr<cql_server::response> cql_server::connection::make_ready(int16_t stream, const tracing::trace_state_ptr& tr_state) const
 {
-    return std::make_unique<cql_server::response>(stream, cql_binary_opcode::READY, tr_state);
+    return create_proper_response(_server._query_processor.local().is_tracing_required(), stream, cql_binary_opcode::READY, tr_state);
 }
 
 std::unique_ptr<cql_server::response> cql_server::connection::make_autheticate(int16_t stream, std::string_view clz, const tracing::trace_state_ptr& tr_state) const
 {
-    auto response = std::make_unique<cql_server::response>(stream, cql_binary_opcode::AUTHENTICATE, tr_state);
+    auto response = create_proper_response(_server._query_processor.local().is_tracing_required(), stream, cql_binary_opcode::AUTHENTICATE, tr_state);
     response->write_string(clz);
     return response;
 }
 
 std::unique_ptr<cql_server::response> cql_server::connection::make_auth_success(int16_t stream, bytes b, const tracing::trace_state_ptr& tr_state) const {
-    auto response = std::make_unique<cql_server::response>(stream, cql_binary_opcode::AUTH_SUCCESS, tr_state);
+    auto response = create_proper_response(_server._query_processor.local().is_tracing_required(), stream, cql_binary_opcode::AUTH_SUCCESS, tr_state);
     response->write_bytes(std::move(b));
     return response;
 }
 
 std::unique_ptr<cql_server::response> cql_server::connection::make_auth_challenge(int16_t stream, bytes b, const tracing::trace_state_ptr& tr_state) const {
-    auto response = std::make_unique<cql_server::response>(stream, cql_binary_opcode::AUTH_CHALLENGE, tr_state);
+    auto response = create_proper_response(_server._query_processor.local().is_tracing_required(), stream, cql_binary_opcode::AUTH_CHALLENGE, tr_state);
     response->write_bytes(std::move(b));
     return response;
 }
@@ -1368,7 +1378,7 @@ std::unique_ptr<cql_server::response> cql_server::connection::make_supported(int
             }
         }
     }
-    auto response = std::make_unique<cql_server::response>(stream, cql_binary_opcode::SUPPORTED, tr_state);
+    auto response = create_proper_response(_server._query_processor.local().is_tracing_required(), stream, cql_binary_opcode::SUPPORTED, tr_state);
     response->write_string_multimap(std::move(opts));
     return response;
 }
@@ -1449,7 +1459,7 @@ public:
 std::unique_ptr<cql_server::response>
 make_result(int16_t stream, messages::result_message& msg, const tracing::trace_state_ptr& tr_state,
         cql_protocol_version_type version, bool skip_metadata) {
-    auto response = std::make_unique<cql_server::response>(stream, cql_binary_opcode::RESULT, tr_state);
+    auto response = create_proper_response(tr_state.has_opentelemetry(), stream, cql_binary_opcode::RESULT, tr_state);
     if (__builtin_expect(!msg.warnings().empty() && version > 3, false)) {
         response->set_frame_flag(cql_frame_flags::warning);
         response->write_string_list(msg.warnings());
@@ -1462,7 +1472,7 @@ make_result(int16_t stream, messages::result_message& msg, const tracing::trace_
 std::unique_ptr<cql_server::response>
 cql_server::connection::make_topology_change_event(const event::topology_change& event) const
 {
-    auto response = std::make_unique<cql_server::response>(-1, cql_binary_opcode::EVENT, tracing::trace_state_ptr());
+    auto response = create_proper_response(_server._query_processor.local().is_tracing_required(), -1, cql_binary_opcode::EVENT, tracing::trace_state_ptr());
     response->write_string("TOPOLOGY_CHANGE");
     response->write_string(to_string(event.change));
     response->write_inet(event.node);
@@ -1472,7 +1482,7 @@ cql_server::connection::make_topology_change_event(const event::topology_change&
 std::unique_ptr<cql_server::response>
 cql_server::connection::make_status_change_event(const event::status_change& event) const
 {
-    auto response = std::make_unique<cql_server::response>(-1, cql_binary_opcode::EVENT, tracing::trace_state_ptr());
+    auto response = create_proper_response(_server._query_processor.local().is_tracing_required(), -1, cql_binary_opcode::EVENT, tracing::trace_state_ptr());
     response->write_string("STATUS_CHANGE");
     response->write_string(to_string(event.status));
     response->write_inet(event.node);
@@ -1482,7 +1492,7 @@ cql_server::connection::make_status_change_event(const event::status_change& eve
 std::unique_ptr<cql_server::response>
 cql_server::connection::make_schema_change_event(const event::schema_change& event) const
 {
-    auto response = std::make_unique<cql_server::response>(-1, cql_binary_opcode::EVENT, tracing::trace_state_ptr());
+    auto response = create_proper_response(_server._query_processor.local().is_tracing_required(), -1, cql_binary_opcode::EVENT, tracing::trace_state_ptr());
     response->write_string("SCHEMA_CHANGE");
     response->serialize(event, _version);
     return response;

--- a/transport/server.cc
+++ b/transport/server.cc
@@ -385,8 +385,11 @@ future<foreign_ptr<std::unique_ptr<cql_server::response>>>
             cqlop == cql_binary_opcode::EXECUTE ||
             cqlop == cql_binary_opcode::BATCH) {
             trace_props.set_if<tracing::trace_state_props::write_on_close>(tracing_request == tracing_request_type::write_on_close);
-            trace_state = tracing::tracing::get_local_tracing_instance().create_session(tracing::trace_type::QUERY, trace_props);
+            trace_state = tracing::tracing::get_local_tracing_instance().create_session(tracing::trace_type::QUERY, trace_props, _server._query_processor.local().is_tracing_required());
         }
+    }
+    else if (_server._query_processor.local().is_tracing_required()) {
+        trace_state = tracing::trace_state_ptr{make_lw_shared<tracing::opentelemetry_state>(nullptr, true)};
     }
 
     tracing::set_request_size(trace_state, fbuf.bytes_left());


### PR DESCRIPTION
The PR introduces passing information about replicas to driver. The PR contains 2 commits as follows:
- keep opentelemetry state in trace_state_ptr - introduces filling trace_state_ptr with proper data depending on tracing options (for classic and openTelemetry tracing)
- send list of connected replicas in custom payload - introduces passing info about connected replicas to client. The list of replicas is serialized and sent to client iff openTelemetry tracing was requested.