### PR TITLE
tracing: store list of contacted replicas in otel tracing

### DIFF
--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -1456,6 +1456,8 @@ storage_proxy::response_id_type storage_proxy::create_write_response_handler(key
     shared_ptr<abstract_write_response_handler> h;
     auto& rs = ks.get_replication_strategy();
 
+    set_replicas(tr_state, targets);
+
     if (db::is_datacenter_local(cl)) {
         h = ::make_shared<datacenter_write_response_handler>(shared_from_this(), ks, cl, type, std::move(m), std::move(targets), pending_endpoints, std::move(dead_endpoints), std::move(tr_state), stats, std::move(permit));
     } else if (cl == db::consistency_level::EACH_QUORUM && rs.get_type() == locator::replication_strategy_type::network_topology){

--- a/tracing/trace_state.cc
+++ b/tracing/trace_state.cc
@@ -338,4 +338,21 @@ sstring trace_state::raw_value_to_sstring(const cql3::raw_value_view& v, const d
       });
     }
 }
+
+void opentelemetry_state::serialize_replicas(bytes& serialized) const {
+    const auto size = htonl(_replicas.size());
+    const auto *size_ptr = reinterpret_cast<const int8_t*>(&size);
+    serialized += bytes{size_ptr, sizeof(size)};
+
+    for (const auto &replica : _replicas) {
+        const auto addr = replica.addr();
+
+        const auto addr_size = static_cast<uint8_t>(addr.size());
+        const auto *addr_size_ptr = reinterpret_cast<const int8_t*>(&addr_size);
+        serialized += bytes{addr_size_ptr, sizeof(addr_size)};
+
+        const auto *addr_data = static_cast<const int8_t*>(addr.data());
+        serialized += bytes{addr_data, addr_size};
+    }
+}
 }


### PR DESCRIPTION
Add information about contacted replicas to opentelemetry_state.