### PR TITLE
send custom payload in response to prepare

### DIFF
--- a/cql3/cql_statement.hh
+++ b/cql3/cql_statement.hh
@@ -118,6 +118,100 @@ public:
     virtual bool is_conditional() const {
         return false;
     }
+
+    enum class cql_statement_type {
+        ALTER_ROLE,
+        CREATE_ROLE,
+        DROP_ROLE,
+        LIST_USERS,
+        GRANT_ROLE,
+        LIST_PERMISSIONS,
+        LIST_ROLES,
+        GRANT,
+        REVOKE,
+        REVOKE_ROLE,
+        ALTER_KEYSPACE,
+        ALTER_TABLE,
+        ALTER_TYPE,
+        ALTER_VIEW,
+        CREATE_INDEX,
+        CREATE_KEYSPACE,
+        CREATE_TABLE,
+        CREATE_TYPE,
+        CREATE_VIEW,
+        DROP_INDEX,
+        DROP_KEYSPACE,
+        DROP_TABLE,
+        DROP_TYPE,
+        DROP_VIEW,
+        CREATE_FUNCTION,
+        CREATE_AGGREGATE,
+        DROP_FUNCTION,
+        DROP_AGGREGATE,
+        ALTER_SERVICE_LEVEL,
+        ATTACH_SERVICE_LEVEL,
+        CREATE_SERVICE_LEVEL,
+        DETACH_SERVICE_LEVEL,
+        DROP_SERVICE_LEVEL,
+        LIST_SERVICE_LEVEL_ATTACHMENTS,
+        LIST_SERVICE_LEVEL,
+        TRUNCATE,
+        USE,
+        PRIMARY_KEY_SELECT,
+        INDEXED_TABLE_SELECT,
+        UPDATE,
+        DELETE,
+        BATCH
+    };
+
+    static seastar::sstring cql_statement_type_name(cql_statement_type st) {
+        switch (st) {
+            case cql_statement_type::ALTER_ROLE: return "ALTER_ROLE";
+            case cql_statement_type::CREATE_ROLE: return "CREATE_ROLE";
+            case cql_statement_type::DROP_ROLE: return "DROP_ROLE";
+            case cql_statement_type::LIST_USERS: return "LIST_USERS";
+            case cql_statement_type::GRANT_ROLE: return "GRANT_ROLE";
+            case cql_statement_type::LIST_PERMISSIONS: return "LIST_PERMISSIONS";
+            case cql_statement_type::LIST_ROLES: return "LIST_ROLES";
+            case cql_statement_type::GRANT: return "GRANT";
+            case cql_statement_type::REVOKE: return "REVOKE";
+            case cql_statement_type::REVOKE_ROLE: return "REVOKE_ROLE";
+            case cql_statement_type::ALTER_KEYSPACE: return "ALTER_KEYSPACE";
+            case cql_statement_type::ALTER_TABLE: return "ALTER_TABLE";
+            case cql_statement_type::ALTER_TYPE: return "ALTER_TYPE";
+            case cql_statement_type::ALTER_VIEW: return "ALTER_VIEW";
+            case cql_statement_type::CREATE_INDEX: return "CREATE_INDEX";
+            case cql_statement_type::CREATE_KEYSPACE: return "CREATE_KEYSPACE";
+            case cql_statement_type::CREATE_TABLE: return "CREATE_TABLE";
+            case cql_statement_type::CREATE_TYPE: return "CREATE_TYPE";
+            case cql_statement_type::CREATE_VIEW: return "CREATE_VIEW";
+            case cql_statement_type::DROP_INDEX: return "DROP_INDEX";
+            case cql_statement_type::DROP_KEYSPACE: return "DROP_KEYSPACE";
+            case cql_statement_type::DROP_TABLE: return "DROP_TABLE";
+            case cql_statement_type::DROP_TYPE: return "DROP_TYPE";
+            case cql_statement_type::DROP_VIEW: return "DROP_VIEW";
+            case cql_statement_type::CREATE_FUNCTION: return "CREATE_FUNCTION";
+            case cql_statement_type::CREATE_AGGREGATE: return "CREATE_AGGREGATE";
+            case cql_statement_type::DROP_FUNCTION: return "DROP_FUNCTION";
+            case cql_statement_type::DROP_AGGREGATE: return "DROP_AGGREGATE";
+            case cql_statement_type::ALTER_SERVICE_LEVEL: return "ALTER_SERVICE_LEVEL";
+            case cql_statement_type::ATTACH_SERVICE_LEVEL: return "ATTACH_SERVICE_LEVEL";
+            case cql_statement_type::CREATE_SERVICE_LEVEL: return "CREATE_SERVICE_LEVEL";
+            case cql_statement_type::DETACH_SERVICE_LEVEL: return "DETACH_SERVICE_LEVEL";
+            case cql_statement_type::DROP_SERVICE_LEVEL: return "DROP_SERVICE_LEVEL";
+            case cql_statement_type::LIST_SERVICE_LEVEL_ATTACHMENTS: return "LIST_SERVICE_LEVEL_ATTACHMENTS";
+            case cql_statement_type::LIST_SERVICE_LEVEL: return "LIST_SERVICE_LEVEL";
+            case cql_statement_type::TRUNCATE: return "TRUNCATE";
+            case cql_statement_type::USE: return "USE";
+            case cql_statement_type::PRIMARY_KEY_SELECT: return "PRIMARY_KEY_SELECT";
+            case cql_statement_type::INDEXED_TABLE_SELECT: return "INDEXED_TABLE_SELECT";
+            case cql_statement_type::UPDATE: return "UPDATE";
+            case cql_statement_type::DELETE: return "DELETE";
+            case cql_statement_type::BATCH: return "BATCH";
+        }
+    }
+
+    virtual cql_statement_type get_statement_type() const = 0;
 };
 
 class cql_statement_no_metadata : public cql_statement {

--- a/cql3/statements/alter_keyspace_statement.hh
+++ b/cql3/statements/alter_keyspace_statement.hh
@@ -67,6 +67,10 @@ public:
     future<shared_ptr<cql_transport::event::schema_change>> announce_migration(query_processor& qp) const override;
     virtual std::unique_ptr<prepared_statement> prepare(database& db, cql_stats& stats) override;
     virtual future<::shared_ptr<messages::result_message>> execute(query_processor& qp, service::query_state& state, const query_options& options) const override;
+
+    inline cql_statement::cql_statement_type get_statement_type() const override {
+        return cql_statement::cql_statement_type::ALTER_KEYSPACE;
+    }
 };
 
 }

--- a/cql3/statements/alter_role_statement.hh
+++ b/cql3/statements/alter_role_statement.hh
@@ -72,6 +72,10 @@ public:
 
     virtual future<::shared_ptr<cql_transport::messages::result_message>>
     execute(query_processor&, service::query_state&, const query_options&) const override;
+
+    inline cql_statement::cql_statement_type get_statement_type() const override {
+        return cql_statement::cql_statement_type::ALTER_ROLE;
+    }
 };
 
 }

--- a/cql3/statements/alter_service_level_statement.hh
+++ b/cql3/statements/alter_service_level_statement.hh
@@ -41,6 +41,10 @@ public:
     virtual future<> check_access(service::storage_proxy& sp, const service::client_state&) const override;
     virtual future<::shared_ptr<cql_transport::messages::result_message>>
     execute(query_processor&, service::query_state&, const query_options&) const override;
+
+    inline cql_statement::cql_statement_type get_statement_type() const override {
+        return cql_statement::cql_statement_type::ALTER_SERVICE_LEVEL;
+    }
 };
 
 }

--- a/cql3/statements/alter_table_statement.hh
+++ b/cql3/statements/alter_table_statement.hh
@@ -69,6 +69,11 @@ public:
         shared_ptr<cql3_type::raw> validator = nullptr;
         bool is_static = false;
     };
+
+    inline cql_statement::cql_statement_type get_statement_type() const override {
+        return cql_statement::cql_statement_type::ALTER_TABLE;
+    }
+
 private:
     const type _type;
     const std::vector<column_change> _column_changes;

--- a/cql3/statements/alter_type_statement.hh
+++ b/cql3/statements/alter_type_statement.hh
@@ -72,6 +72,10 @@ public:
 
     virtual future<shared_ptr<cql_transport::event::schema_change>> announce_migration(query_processor& qp) const override;
 
+    inline cql_statement::cql_statement_type get_statement_type() const override {
+        return cql_statement::cql_statement_type::ALTER_TYPE;
+    }
+
     class add_or_alter;
     class renames;
 protected:

--- a/cql3/statements/alter_view_statement.hh
+++ b/cql3/statements/alter_view_statement.hh
@@ -68,6 +68,10 @@ public:
     virtual future<shared_ptr<cql_transport::event::schema_change>> announce_migration(query_processor& qp) const override;
 
     virtual std::unique_ptr<prepared_statement> prepare(database& db, cql_stats& stats) override;
+
+    inline cql_statement::cql_statement_type get_statement_type() const override {
+        return cql_statement::cql_statement_type::ALTER_VIEW;
+    }
 };
 
 }

--- a/cql3/statements/attach_service_level_statement.hh
+++ b/cql3/statements/attach_service_level_statement.hh
@@ -40,6 +40,10 @@ public:
     virtual future<> check_access(service::storage_proxy& sp, const service::client_state&) const override;
     virtual future<::shared_ptr<cql_transport::messages::result_message>>
     execute(query_processor&, service::query_state&, const query_options&) const override;
+
+    inline cql_statement::cql_statement_type get_statement_type() const override {
+        return cql_statement::cql_statement_type::ATTACH_SERVICE_LEVEL;
+    }
 };
 
 }

--- a/cql3/statements/batch_statement.hh
+++ b/cql3/statements/batch_statement.hh
@@ -78,6 +78,11 @@ public:
             , needs_authorization(na)
         {}
     };
+
+    inline cql_statement::cql_statement_type get_statement_type() const override {
+        return cql_statement::cql_statement_type::BATCH;
+    }
+
 private:
     int _bound_terms;
     type _type;

--- a/cql3/statements/create_aggregate_statement.hh
+++ b/cql3/statements/create_aggregate_statement.hh
@@ -51,6 +51,10 @@ class create_aggregate_statement final : public create_function_statement_base {
 public:
     create_aggregate_statement(functions::function_name name, std::vector<shared_ptr<cql3_type::raw>> arg_types,
             sstring sfunc, shared_ptr<cql3_type::raw> stype, sstring ffunc, expr::expression ival, bool or_replace, bool if_not_exists);
+
+    inline cql_statement::cql_statement_type get_statement_type() const override {
+        return cql_statement::cql_statement_type::CREATE_AGGREGATE;
+    }
 };
 }
 }

--- a/cql3/statements/create_function_statement.hh
+++ b/cql3/statements/create_function_statement.hh
@@ -54,6 +54,10 @@ public:
     create_function_statement(functions::function_name name, sstring language, sstring body,
             std::vector<shared_ptr<column_identifier>> arg_names, std::vector<shared_ptr<cql3_type::raw>> arg_types,
             shared_ptr<cql3_type::raw> return_type, bool called_on_null_input, bool or_replace, bool if_not_exists);
+
+    inline cql_statement::cql_statement_type get_statement_type() const override {
+        return cql_statement::cql_statement_type::CREATE_FUNCTION;
+    }
 };
 }
 }

--- a/cql3/statements/create_index_statement.hh
+++ b/cql3/statements/create_index_statement.hh
@@ -81,6 +81,11 @@ public:
     future<::shared_ptr<cql_transport::event::schema_change>> announce_migration(query_processor&) const override;
 
     virtual std::unique_ptr<prepared_statement> prepare(database& db, cql_stats& stats) override;
+
+    inline cql_statement::cql_statement_type get_statement_type() const override {
+        return cql_statement::cql_statement_type::CREATE_INDEX;
+    }
+
 private:
     void validate_for_local_index(const schema& schema) const;
     void validate_for_frozen_collection(const index_target& target) const;

--- a/cql3/statements/create_keyspace_statement.hh
+++ b/cql3/statements/create_keyspace_statement.hh
@@ -102,6 +102,10 @@ public:
     execute(query_processor& qp, service::query_state& state, const query_options& options) const override;
 
     lw_shared_ptr<keyspace_metadata> get_keyspace_metadata(const locator::token_metadata& tm);
+
+    inline cql_statement::cql_statement_type get_statement_type() const override {
+        return cql_statement::cql_statement_type::CREATE_KEYSPACE;
+    }
 };
 
 std::optional<sstring> check_restricted_replication_strategy(

--- a/cql3/statements/create_role_statement.hh
+++ b/cql3/statements/create_role_statement.hh
@@ -78,6 +78,10 @@ public:
 
     virtual future<::shared_ptr<cql_transport::messages::result_message>>
     execute(query_processor&, service::query_state&, const query_options&) const override;
+
+    inline cql_statement::cql_statement_type get_statement_type() const override {
+        return cql_statement::cql_statement_type::CREATE_ROLE;
+    }
 };
 
 }

--- a/cql3/statements/create_service_level_statement.hh
+++ b/cql3/statements/create_service_level_statement.hh
@@ -42,6 +42,10 @@ public:
     virtual future<> check_access(service::storage_proxy& sp, const service::client_state&) const override;
     virtual future<::shared_ptr<cql_transport::messages::result_message>>
     execute(query_processor&, service::query_state&, const query_options&) const override;
+
+    inline cql_statement::cql_statement_type get_statement_type() const override {
+        return cql_statement::cql_statement_type::CREATE_SERVICE_LEVEL;
+    }
 };
 
 }

--- a/cql3/statements/create_table_statement.hh
+++ b/cql3/statements/create_table_statement.hh
@@ -114,6 +114,10 @@ public:
 
     schema_ptr get_cf_meta_data(const database&) const;
 
+    inline cql_statement::cql_statement_type get_statement_type() const override {
+        return cql_statement::cql_statement_type::CREATE_TABLE;
+    }
+
     class raw_statement;
 
     friend raw_statement;

--- a/cql3/statements/create_type_statement.hh
+++ b/cql3/statements/create_type_statement.hh
@@ -74,6 +74,10 @@ public:
 
     static void check_for_duplicate_names(user_type type);
 
+    inline cql_statement::cql_statement_type get_statement_type() const override {
+        return cql_statement::cql_statement_type::CREATE_TYPE;
+    }
+
 private:
     bool type_exists_in(::keyspace& ks) const;
 

--- a/cql3/statements/create_view_statement.hh
+++ b/cql3/statements/create_view_statement.hh
@@ -72,6 +72,9 @@ public:
     virtual future<shared_ptr<cql_transport::event::schema_change>> announce_migration(query_processor& qp) const override;
     virtual std::unique_ptr<prepared_statement> prepare(database& db, cql_stats& stats) override;
 
+    inline cql_statement::cql_statement_type get_statement_type() const override {
+        return cql_statement::cql_statement_type::CREATE_VIEW;
+    }
     // FIXME: continue here. See create_table_statement.hh and CreateViewStatement.java
 };
 

--- a/cql3/statements/delete_statement.hh
+++ b/cql3/statements/delete_statement.hh
@@ -62,6 +62,10 @@ public:
     virtual bool allow_clustering_key_slices() const override;
 
     virtual void add_update_for_key(mutation& m, const query::clustering_range& range, const update_parameters& params, const json_cache_opt& json_cache) const override;
+
+    inline cql_statement::cql_statement_type get_statement_type() const override {
+        return cql_statement::cql_statement_type::DELETE;
+    }
 };
 
 }

--- a/cql3/statements/detach_service_level_statement.hh
+++ b/cql3/statements/detach_service_level_statement.hh
@@ -38,6 +38,10 @@ public:
     virtual future<> check_access(service::storage_proxy& sp, const service::client_state&) const override;
     virtual future<::shared_ptr<cql_transport::messages::result_message>>
     execute(query_processor&, service::query_state&, const query_options&) const override;
+
+    inline cql_statement::cql_statement_type get_statement_type() const override {
+        return cql_statement::cql_statement_type::DETACH_SERVICE_LEVEL;
+    }
 };
 
 }

--- a/cql3/statements/drop_aggregate_statement.hh
+++ b/cql3/statements/drop_aggregate_statement.hh
@@ -34,6 +34,10 @@ class drop_aggregate_statement final : public drop_function_statement_base {
 public:
     drop_aggregate_statement(functions::function_name name, std::vector<shared_ptr<cql3_type::raw>> arg_types,
             bool args_present, bool if_exists);
+
+    inline cql_statement::cql_statement_type get_statement_type() const override {
+        return cql_statement::cql_statement_type::DROP_AGGREGATE;
+    }
 };
 }
 }

--- a/cql3/statements/drop_function_statement.hh
+++ b/cql3/statements/drop_function_statement.hh
@@ -34,6 +34,10 @@ class drop_function_statement final : public drop_function_statement_base {
 public:
     drop_function_statement(functions::function_name name, std::vector<shared_ptr<cql3_type::raw>> arg_types,
             bool args_present, bool if_exists);
+
+    inline cql_statement::cql_statement_type get_statement_type() const override {
+        return cql_statement::cql_statement_type::DROP_FUNCTION;
+    }
 };
 }
 }

--- a/cql3/statements/drop_index_statement.hh
+++ b/cql3/statements/drop_index_statement.hh
@@ -78,6 +78,11 @@ public:
     virtual future<shared_ptr<cql_transport::event::schema_change>> announce_migration(query_processor& qp) const override;
 
     virtual std::unique_ptr<prepared_statement> prepare(database& db, cql_stats& stats) override;
+
+    inline cql_statement::cql_statement_type get_statement_type() const override {
+        return cql_statement::cql_statement_type::DROP_INDEX;
+    }
+
 private:
     schema_ptr lookup_indexed_table(service::storage_proxy& proxy) const;
 };

--- a/cql3/statements/drop_keyspace_statement.hh
+++ b/cql3/statements/drop_keyspace_statement.hh
@@ -64,6 +64,10 @@ public:
     virtual future<shared_ptr<cql_transport::event::schema_change>> announce_migration(query_processor& qp) const override;
 
     virtual std::unique_ptr<prepared_statement> prepare(database& db, cql_stats& stats) override;
+
+    inline cql_statement::cql_statement_type get_statement_type() const override {
+        return cql_statement::cql_statement_type::DROP_KEYSPACE;
+    }
 };
 
 }

--- a/cql3/statements/drop_role_statement.hh
+++ b/cql3/statements/drop_role_statement.hh
@@ -70,6 +70,10 @@ public:
 
     virtual future<::shared_ptr<cql_transport::messages::result_message>>
     execute(query_processor&, service::query_state&, const query_options&) const override;
+
+    inline cql_statement::cql_statement_type get_statement_type() const override {
+        return cql_statement::cql_statement_type::DROP_ROLE;
+    }
 };
 
 }

--- a/cql3/statements/drop_service_level_statement.hh
+++ b/cql3/statements/drop_service_level_statement.hh
@@ -39,6 +39,10 @@ public:
     virtual future<> check_access(service::storage_proxy& sp, const service::client_state&) const override;
     virtual future<::shared_ptr<cql_transport::messages::result_message>>
     execute(query_processor&, service::query_state&, const query_options&) const override;
+
+    inline cql_statement::cql_statement_type get_statement_type() const override {
+        return cql_statement::cql_statement_type::DROP_SERVICE_LEVEL;
+    }
 };
 
 }

--- a/cql3/statements/drop_table_statement.hh
+++ b/cql3/statements/drop_table_statement.hh
@@ -62,6 +62,10 @@ public:
     virtual future<shared_ptr<cql_transport::event::schema_change>> announce_migration(query_processor& qp) const override;
 
     virtual std::unique_ptr<prepared_statement> prepare(database& db, cql_stats& stats) override;
+
+    inline cql_statement::cql_statement_type get_statement_type() const override {
+        return cql_statement::cql_statement_type::DROP_TABLE;
+    }
 };
 
 }

--- a/cql3/statements/drop_type_statement.hh
+++ b/cql3/statements/drop_type_statement.hh
@@ -65,6 +65,10 @@ public:
     virtual future<shared_ptr<cql_transport::event::schema_change>> announce_migration(query_processor& qp) const override;
 
     virtual std::unique_ptr<prepared_statement> prepare(database& db, cql_stats& stats) override;
+
+    inline cql_statement::cql_statement_type get_statement_type() const override {
+        return cql_statement::cql_statement_type::DROP_TYPE;
+    }
 };
 
 }

--- a/cql3/statements/drop_view_statement.hh
+++ b/cql3/statements/drop_view_statement.hh
@@ -68,6 +68,10 @@ public:
     virtual future<shared_ptr<cql_transport::event::schema_change>> announce_migration(query_processor& qp) const override;
 
     virtual std::unique_ptr<prepared_statement> prepare(database& db, cql_stats& stats) override;
+
+    inline cql_statement::cql_statement_type get_statement_type() const override {
+        return cql_statement::cql_statement_type::DROP_VIEW;
+    }
 };
 
 }

--- a/cql3/statements/grant_role_statement.hh
+++ b/cql3/statements/grant_role_statement.hh
@@ -69,6 +69,10 @@ public:
 
     virtual future<::shared_ptr<cql_transport::messages::result_message>>
     execute(query_processor&, service::query_state&, const query_options&) const override;
+
+    inline cql_statement::cql_statement_type get_statement_type() const override {
+        return cql_statement::cql_statement_type::GRANT_ROLE;
+    }
 };
 
 }

--- a/cql3/statements/grant_statement.hh
+++ b/cql3/statements/grant_statement.hh
@@ -58,6 +58,10 @@ public:
     future<::shared_ptr<cql_transport::messages::result_message>> execute(query_processor&
                     , service::query_state&
                     , const query_options&) const override;
+
+    inline cql_statement::cql_statement_type get_statement_type() const override {
+        return cql_statement::cql_statement_type::GRANT;
+    }
 };
 
 }

--- a/cql3/statements/list_permissions_statement.hh
+++ b/cql3/statements/list_permissions_statement.hh
@@ -71,6 +71,10 @@ public:
 
     future<::shared_ptr<cql_transport::messages::result_message>>
     execute(query_processor&, service::query_state& , const query_options&) const override;
+
+    inline cql_statement::cql_statement_type get_statement_type() const override {
+        return cql_statement::cql_statement_type::LIST_PERMISSIONS;
+    }
 };
 
 }

--- a/cql3/statements/list_roles_statement.hh
+++ b/cql3/statements/list_roles_statement.hh
@@ -70,6 +70,10 @@ public:
 
     virtual future<::shared_ptr<cql_transport::messages::result_message>>
     execute(query_processor&, service::query_state&, const query_options&) const override;
+
+    inline cql_statement::cql_statement_type get_statement_type() const override {
+        return cql_statement::cql_statement_type::LIST_ROLES;
+    }
 };
 
 }

--- a/cql3/statements/list_service_level_attachments_statement.hh
+++ b/cql3/statements/list_service_level_attachments_statement.hh
@@ -40,6 +40,10 @@ public:
     virtual future<> check_access(service::storage_proxy& sp, const service::client_state&) const override;
     virtual future<::shared_ptr<cql_transport::messages::result_message>>
     execute(query_processor&, service::query_state&, const query_options&) const override;
+
+    inline cql_statement::cql_statement_type get_statement_type() const override {
+        return cql_statement::cql_statement_type::LIST_SERVICE_LEVEL_ATTACHMENTS;
+    }
 };
 
 }

--- a/cql3/statements/list_service_level_statement.hh
+++ b/cql3/statements/list_service_level_statement.hh
@@ -39,6 +39,10 @@ public:
     virtual future<> check_access(service::storage_proxy& sp, const service::client_state&) const override;
     virtual future<::shared_ptr<cql_transport::messages::result_message>>
     execute(query_processor&, service::query_state&, const query_options&) const override;
+
+    inline cql_statement::cql_statement_type get_statement_type() const override {
+        return cql_statement::cql_statement_type::LIST_SERVICE_LEVEL;
+    }
 };
 
 }

--- a/cql3/statements/list_users_statement.hh
+++ b/cql3/statements/list_users_statement.hh
@@ -59,6 +59,10 @@ public:
     future<::shared_ptr<cql_transport::messages::result_message>> execute(query_processor&
                     , service::query_state&
                     , const query_options&) const override;
+
+    inline cql_statement::cql_statement_type get_statement_type() const override {
+        return cql_statement::cql_statement_type::LIST_USERS;
+    }
 };
 
 }

--- a/cql3/statements/revoke_role_statement.hh
+++ b/cql3/statements/revoke_role_statement.hh
@@ -69,6 +69,10 @@ public:
 
     virtual future<::shared_ptr<cql_transport::messages::result_message>>
     execute(query_processor&, service::query_state&, const query_options&) const override;
+
+    inline cql_statement::cql_statement_type get_statement_type() const override {
+        return cql_statement::cql_statement_type::REVOKE_ROLE;
+    }
 };
 
 }

--- a/cql3/statements/revoke_statement.hh
+++ b/cql3/statements/revoke_statement.hh
@@ -58,6 +58,10 @@ public:
     future<::shared_ptr<cql_transport::messages::result_message>> execute(query_processor&
                     , service::query_state&
                     , const query_options&) const override;
+
+    inline cql_statement::cql_statement_type get_statement_type() const override {
+        return cql_statement::cql_statement_type::REVOKE;
+    }
 };
 
 }

--- a/cql3/statements/select_statement.hh
+++ b/cql3/statements/select_statement.hh
@@ -186,6 +186,10 @@ public:
                      std::optional<expr::expression> per_partition_limit,
                      cql_stats &stats,
                      std::unique_ptr<cql3::attributes> attrs);
+
+    inline cql_statement::cql_statement_type get_statement_type() const override {
+        return cql_statement::cql_statement_type::PRIMARY_KEY_SELECT;
+    }
 };
 
 class indexed_table_select_statement : public select_statement {
@@ -226,6 +230,10 @@ public:
                                    ::shared_ptr<restrictions::restrictions> used_index_restrictions,
                                    schema_ptr view_schema,
                                    std::unique_ptr<cql3::attributes> attrs);
+
+    inline cql_statement::cql_statement_type get_statement_type() const override {
+        return cql_statement::cql_statement_type::INDEXED_TABLE_SELECT;
+    }
 
 private:
     virtual future<::shared_ptr<cql_transport::messages::result_message>> do_execute(service::storage_proxy& proxy,

--- a/cql3/statements/truncate_statement.hh
+++ b/cql3/statements/truncate_statement.hh
@@ -68,6 +68,10 @@ public:
 
     virtual future<::shared_ptr<cql_transport::messages::result_message>>
     execute(query_processor& qp, service::query_state& state, const query_options& options) const override;
+
+    inline cql_statement::cql_statement_type get_statement_type() const override {
+        return cql_statement::cql_statement_type::TRUNCATE;
+    }
 };
 
 }

--- a/cql3/statements/update_statement.hh
+++ b/cql3/statements/update_statement.hh
@@ -65,6 +65,11 @@ public:
             schema_ptr s,
             std::unique_ptr<attributes> attrs,
             cql_stats& stats);
+
+    inline cql_statement::cql_statement_type get_statement_type() const override {
+        return cql_statement::cql_statement_type::UPDATE;
+    }
+
 private:
     virtual bool require_full_clustering_key() const override;
 

--- a/cql3/statements/use_statement.hh
+++ b/cql3/statements/use_statement.hh
@@ -69,6 +69,10 @@ public:
 
     virtual seastar::future<seastar::shared_ptr<cql_transport::messages::result_message>>
     execute(query_processor& qp, service::query_state& state, const query_options& options) const override;
+
+    inline cql_statement::cql_statement_type get_statement_type() const override {
+        return cql_statement::cql_statement_type::USE;
+    }
 };
 
 }

--- a/transport/messages/result_message_base.hh
+++ b/transport/messages/result_message_base.hh
@@ -32,6 +32,7 @@ namespace messages {
 
 class result_message {
     std::vector<sstring> _warnings;
+    std::map<sstring, bytes> _custom_payload;
 public:
     class visitor;
     class visitor_base;
@@ -46,6 +47,14 @@ public:
 
     const std::vector<sstring>& warnings() const {
         return _warnings;
+    }
+
+    void add_to_custom_payload(sstring key, bytes val) {
+        _custom_payload[key] = val;
+    }
+
+    const std::map<sstring, bytes>& custom_payload() const {
+        return _custom_payload;
     }
 
     virtual std::optional<unsigned> move_to_shard() const {

--- a/transport/server.cc
+++ b/transport/server.cc
@@ -1446,7 +1446,9 @@ public:
 std::unique_ptr<cql_server::response>
 make_result(int16_t stream, messages::result_message& msg, const tracing::trace_state_ptr& tr_state,
         cql_protocol_version_type version, bool skip_metadata) {
-    auto response = std::make_unique<cql_server::response>(stream, cql_binary_opcode::RESULT, tr_state);
+    auto response = (msg.custom_payload().empty()) ?
+        std::make_unique<cql_server::response>(stream, cql_binary_opcode::RESULT, tr_state) :
+        std::make_unique<cql_server::response>(stream, cql_binary_opcode::RESULT, tr_state, msg.custom_payload());
     if (__builtin_expect(!msg.warnings().empty() && version > 3, false)) {
         response->set_frame_flag(cql_frame_flags::warning);
         response->write_string_list(msg.warnings());


### PR DESCRIPTION
The PR introduces sending prepared operation type (SELECT/UPDATE/DELETE etc.) in custom payload in response to PREPARE message. This information is obtained by using virtual method `get_statement_type()` added to `cql_statement` and implemented in it's subclasses.