### PR TITLE
Opentelemetry rpc negotiation

### DIFF
--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -5101,6 +5101,15 @@ void storage_proxy::init_messaging_service(shared_ptr<migration_manager> mm) {
             trace_state_ptr = tracing::tracing::get_local_tracing_instance().create_session(*cmd.trace_info);
             tracing::begin(trace_state_ptr);
             tracing::trace(trace_state_ptr, "read_data: message received from /{}", src_addr.addr);
+            if (trace_state_ptr.has_opentelemetry()) {
+                printf("OpenTelemetry tracing on.");
+            }
+            else {
+                printf("No OpenTelemetry tracing.");
+            }
+        }
+        else {
+            printf("No tracing at all.");
         }
         auto da = oda.value_or(query::digest_algorithm::MD5);
         auto sp = get_local_shared_storage_proxy();

--- a/tracing/tracing.cc
+++ b/tracing/tracing.cc
@@ -116,11 +116,11 @@ future<> tracing::stop_tracing() {
 }
 
 trace_state_ptr tracing::create_session(trace_type type, trace_state_props_set props, bool opentelemetry_tracing) noexcept {
-    if (!started()) {
-        return opentelemetry_tracing ? make_lw_shared<opentelemetry_state>(nullptr, opentelemetry_tracing) : nullptr;
-    }
-
     try {
+        if (!started()) {
+            return opentelemetry_tracing ? make_lw_shared<opentelemetry_state>(nullptr, opentelemetry_tracing) : nullptr;
+        }
+
         // Don't create a session if its records are likely to be dropped
         if (!may_create_new_session()) {
             return opentelemetry_tracing ? make_lw_shared<opentelemetry_state>(nullptr, opentelemetry_tracing) : nullptr;
@@ -138,18 +138,22 @@ trace_state_ptr tracing::create_session(trace_type type, trace_state_props_set p
 }
 
 trace_state_ptr tracing::create_session(const trace_info& secondary_session_info) noexcept {
-    if (!started()) {
-        return nullptr;
-    }
-
     try {
+        bool opentelemetry_tracing = secondary_session_info.state_props.contains(trace_state_props::opentelemetry);
+        if (!started()) {
+            return opentelemetry_tracing ? make_lw_shared<opentelemetry_state>(nullptr, opentelemetry_tracing) : nullptr;
+        }
+
         // Don't create a session if its records are likely to be dropped
         if (!may_create_new_session(secondary_session_info.session_id)) {
-            return nullptr;
+            return opentelemetry_tracing ? make_lw_shared<opentelemetry_state>(nullptr, opentelemetry_tracing) : nullptr;
         }
 
         ++_active_sessions;
-        return make_lw_shared<trace_state>(secondary_session_info);
+        if (secondary_session_info.state_props.contains(trace_state_props::classic)) {
+            return make_lw_shared<opentelemetry_state>(make_lw_shared<trace_state>(secondary_session_info), opentelemetry_tracing);
+        }
+        return make_lw_shared<opentelemetry_state>(nullptr, opentelemetry_tracing);
     } catch (...) {
         // return an uninitialized state in case of any error (OOM?)
         return nullptr;

--- a/tracing/tracing.hh
+++ b/tracing/tracing.hh
@@ -129,7 +129,7 @@ std::ostream& operator<<(std::ostream& os, const span_id& id);
 //
 // Otherwise this may break IDL's backward compatibility.
 enum class trace_state_props {
-    write_on_close, primary, log_slow_query, full_tracing, ignore_events
+    write_on_close, primary, log_slow_query, full_tracing, ignore_events, opentelemetry, classic
 };
 
 using trace_state_props_set = enum_set<super_enum<trace_state_props,
@@ -137,7 +137,9 @@ using trace_state_props_set = enum_set<super_enum<trace_state_props,
     trace_state_props::primary,
     trace_state_props::log_slow_query,
     trace_state_props::full_tracing,
-    trace_state_props::ignore_events>>;
+    trace_state_props::ignore_events,
+    trace_state_props::opentelemetry,
+    trace_state_props::classic>>;
 
 class trace_info {
 public:
@@ -161,6 +163,8 @@ public:
     {
         state_props.set_if<trace_state_props::write_on_close>(write_on_close);
     }
+
+    trace_info(trace_state_props_set s_p) : state_props(s_p) {}
 };
 
 struct one_session_records;


### PR DESCRIPTION
The PR introduces passing decision about OpenTelemetry tracing from coordinator to replicas.
The `trace_state_props` is extended to contain information about the type of requested tracing and thus the decision is stored and passed in `trace_info`.
