### PR TITLE
Opentelemetry cache counter

### DIFF
--- a/cql3/result_set.hh
+++ b/cql3/result_set.hh
@@ -193,7 +193,7 @@ public:
 
     template<typename RowComparator>
     void sort(const RowComparator& cmp) {
-        std::sort(_rows.begin(), _rows.end(), std::ref(cmp));
+        std::sort(_rows.begin(), _rows.end(), cmp);
     }
 
     metadata& get_metadata();

--- a/message/messaging_service.cc
+++ b/message/messaging_service.cc
@@ -1061,14 +1061,14 @@ future<> messaging_service::send_mutation_failed(msg_addr id, unsigned shard, re
     return send_message_oneway(this, messaging_verb::MUTATION_FAILED, std::move(id), shard, std::move(response_id), num_failed, std::move(backlog));
 }
 
-void messaging_service::register_read_data(std::function<future<rpc::tuple<foreign_ptr<lw_shared_ptr<query::result>>, cache_temperature>> (const rpc::client_info&, rpc::opt_time_point t, query::read_command cmd, ::compat::wrapping_partition_range pr, rpc::optional<query::digest_algorithm> oda)>&& func) {
+void messaging_service::register_read_data(std::function<future<rpc::tuple<foreign_ptr<lw_shared_ptr<query::result>>, cache_temperature, tracing::trace_state_ptr::cache_counter_t>> (const rpc::client_info&, rpc::opt_time_point t, query::read_command cmd, ::compat::wrapping_partition_range pr, rpc::optional<query::digest_algorithm> oda)>&& func) {
     register_handler(this, netw::messaging_verb::READ_DATA, std::move(func));
 }
 future<> messaging_service::unregister_read_data() {
     return unregister_handler(netw::messaging_verb::READ_DATA);
 }
-future<rpc::tuple<query::result, rpc::optional<cache_temperature>>> messaging_service::send_read_data(msg_addr id, clock_type::time_point timeout, const query::read_command& cmd, const dht::partition_range& pr, query::digest_algorithm da) {
-    return send_message_timeout<future<rpc::tuple<query::result, rpc::optional<cache_temperature>>>>(this, messaging_verb::READ_DATA, std::move(id), timeout, cmd, pr, da);
+future<rpc::tuple<query::result, rpc::optional<cache_temperature>, tracing::trace_state_ptr::cache_counter_t>> messaging_service::send_read_data(msg_addr id, clock_type::time_point timeout, const query::read_command& cmd, const dht::partition_range& pr, query::digest_algorithm da) {
+    return send_message_timeout<future<rpc::tuple<query::result, rpc::optional<cache_temperature>, tracing::trace_state_ptr::cache_counter_t>>>(this, messaging_verb::READ_DATA, std::move(id), timeout, cmd, pr, da);
 }
 
 void messaging_service::register_get_schema_version(std::function<future<frozen_schema>(unsigned, table_schema_version)>&& func) {

--- a/message/messaging_service.hh
+++ b/message/messaging_service.hh
@@ -34,6 +34,7 @@
 #include "mutation_query.hh"
 #include "range.hh"
 #include "repair/repair.hh"
+#include "tracing/trace_state.hh"
 #include "tracing/tracing.hh"
 #include "digest_algorithm.hh"
 #include "streaming/stream_reason.hh"
@@ -481,9 +482,9 @@ public:
 
     // Wrapper for READ_DATA
     // Note: WTH is future<foreign_ptr<lw_shared_ptr<query::result>>
-    void register_read_data(std::function<future<rpc::tuple<foreign_ptr<lw_shared_ptr<query::result>>, cache_temperature>> (const rpc::client_info&, rpc::opt_time_point timeout, query::read_command cmd, ::compat::wrapping_partition_range pr, rpc::optional<query::digest_algorithm> digest)>&& func);
+    void register_read_data(std::function<future<rpc::tuple<foreign_ptr<lw_shared_ptr<query::result>>, cache_temperature, tracing::trace_state_ptr::cache_counter_t>> (const rpc::client_info&, rpc::opt_time_point timeout, query::read_command cmd, ::compat::wrapping_partition_range pr, rpc::optional<query::digest_algorithm> digest)>&& func);
     future<> unregister_read_data();
-    future<rpc::tuple<query::result, rpc::optional<cache_temperature>>> send_read_data(msg_addr id, clock_type::time_point timeout, const query::read_command& cmd, const dht::partition_range& pr, query::digest_algorithm da);
+    future<rpc::tuple<query::result, rpc::optional<cache_temperature>, tracing::trace_state_ptr::cache_counter_t>> send_read_data(msg_addr id, clock_type::time_point timeout, const query::read_command& cmd, const dht::partition_range& pr, query::digest_algorithm da);
 
     // Wrapper for GET_SCHEMA_VERSION
     void register_get_schema_version(std::function<future<frozen_schema>(unsigned, table_schema_version)>&& func);

--- a/row_cache.cc
+++ b/row_cache.cc
@@ -741,6 +741,7 @@ row_cache::do_make_reader(schema_ptr s,
     if (query::is_single_partition(range) && !fwd_mr) {
         tracing::trace(trace_state, "Querying cache for range {} and slice {}",
                 range, seastar::value_of([&slice] { return slice.get_all_ranges(); }));
+        modify_cache_counter(trace_state, 1);
         return _read_section(_tracker.region(), [&] {
             dht::ring_position_comparator cmp(*_schema);
             auto&& pos = range.start()->value();
@@ -756,6 +757,7 @@ row_cache::do_make_reader(schema_ptr s,
             } else {
                 tracing::trace(trace_state, "Range {} not found in cache", range);
                 on_partition_miss();
+                modify_cache_counter(trace_state, -1);
                 return make_flat_mutation_reader<single_partition_populating_reader>(*this, make_context());
             }
         });

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -3549,7 +3549,7 @@ protected:
             });
         }
     }
-    future<rpc::tuple<foreign_ptr<lw_shared_ptr<query::result>>, cache_temperature>> make_data_request(gms::inet_address ep, clock_type::time_point timeout, bool want_digest) {
+    future<rpc::tuple<foreign_ptr<lw_shared_ptr<query::result>>, cache_temperature, tracing::trace_state_ptr::cache_counter_t>> make_data_request(gms::inet_address ep, clock_type::time_point timeout, bool want_digest) {
         ++_proxy->get_stats().data_read_attempts.get_ep_stat(ep);
         auto opts = want_digest
                   ? query::result_options{query::result_request::result_and_digest, digest_algorithm(*_proxy)}
@@ -3559,10 +3559,11 @@ protected:
             return _proxy->query_result_local(_schema, _cmd, _partition_range, opts, _trace_state, timeout);
         } else {
             tracing::trace(_trace_state, "read_data: sending a message to /{}", ep);
-            return _proxy->_messaging.send_read_data(netw::messaging_service::msg_addr{ep, 0}, timeout, *_cmd, _partition_range, opts.digest_algo).then([this, ep](rpc::tuple<query::result, rpc::optional<cache_temperature>> result_hit_rate) {
-                auto&& [result, hit_rate] = result_hit_rate;
+            return _proxy->_messaging.send_read_data(netw::messaging_service::msg_addr{ep, 0}, timeout, *_cmd, _partition_range, opts.digest_algo).then([this, ep](rpc::tuple<query::result, rpc::optional<cache_temperature>, tracing::trace_state_ptr::cache_counter_t> result_hit_rate) {
+                auto&& [result, hit_rate, cache_counter] = result_hit_rate;
                 tracing::trace(_trace_state, "read_data: got response from /{}", ep);
-                return make_ready_future<rpc::tuple<foreign_ptr<lw_shared_ptr<query::result>>, cache_temperature>>(rpc::tuple(make_foreign(::make_lw_shared<query::result>(std::move(result))), hit_rate.value_or(cache_temperature::invalid())));
+                tracing::modify_cache_counter(_trace_state, cache_counter);
+                return make_ready_future<rpc::tuple<foreign_ptr<lw_shared_ptr<query::result>>, cache_temperature, tracing::trace_state_ptr::cache_counter_t>>(rpc::tuple(make_foreign(::make_lw_shared<query::result>(std::move(result))), hit_rate.value_or(cache_temperature::invalid()), cache_counter));
             });
         }
     }
@@ -3605,7 +3606,7 @@ protected:
         auto start = latency_clock::now();
         for (const gms::inet_address& ep : boost::make_iterator_range(begin, end)) {
             // Waited on indirectly, shared_from_this keeps `this` alive
-            (void)make_data_request(ep, timeout, want_digest).then_wrapped([this, resolver, ep, start, exec = shared_from_this()] (future<rpc::tuple<foreign_ptr<lw_shared_ptr<query::result>>, cache_temperature>> f) {
+            (void)make_data_request(ep, timeout, want_digest).then_wrapped([this, resolver, ep, start, exec = shared_from_this()] (future<rpc::tuple<foreign_ptr<lw_shared_ptr<query::result>>, cache_temperature, tracing::trace_state_ptr::cache_counter_t>> f) {
                 try {
                     auto v = f.get0();
                     _cf->set_hit_rate(ep, std::get<1>(v));
@@ -4006,13 +4007,13 @@ db::read_repair_decision storage_proxy::new_read_repair_decision(const schema& s
 
 future<rpc::tuple<query::result_digest, api::timestamp_type, cache_temperature>>
 storage_proxy::query_result_local_digest(schema_ptr s, lw_shared_ptr<query::read_command> cmd, const dht::partition_range& pr, tracing::trace_state_ptr trace_state, storage_proxy::clock_type::time_point timeout, query::digest_algorithm da) {
-    return query_result_local(std::move(s), std::move(cmd), pr, query::result_options::only_digest(da), std::move(trace_state), timeout).then([] (rpc::tuple<foreign_ptr<lw_shared_ptr<query::result>>, cache_temperature> result_and_hit_rate) {
-        auto&& [result, hit_rate] = result_and_hit_rate;
+    return query_result_local(std::move(s), std::move(cmd), pr, query::result_options::only_digest(da), std::move(trace_state), timeout).then([] (rpc::tuple<foreign_ptr<lw_shared_ptr<query::result>>, cache_temperature, tracing::trace_state_ptr::cache_counter_t> result_and_hit_rate) {
+        auto&& [result, hit_rate, cache_counter] = result_and_hit_rate;
         return make_ready_future<rpc::tuple<query::result_digest, api::timestamp_type, cache_temperature>>(rpc::tuple(*result->digest(), result->last_modified(), hit_rate));
     });
 }
 
-future<rpc::tuple<foreign_ptr<lw_shared_ptr<query::result>>, cache_temperature>>
+future<rpc::tuple<foreign_ptr<lw_shared_ptr<query::result>>, cache_temperature, tracing::trace_state_ptr::cache_counter_t>>
 storage_proxy::query_result_local(schema_ptr s, lw_shared_ptr<query::read_command> cmd, const dht::partition_range& pr, query::result_options opts,
                                   tracing::trace_state_ptr trace_state, storage_proxy::clock_type::time_point timeout) {
     cmd->slice.options.set_if<query::partition_slice::option::with_digest>(opts.request != query::result_request::only_result);
@@ -4025,7 +4026,7 @@ storage_proxy::query_result_local(schema_ptr s, lw_shared_ptr<query::read_comman
             return db.query(gs, *cmd, opts, prv, trace_state, timeout).then([trace_state](std::tuple<lw_shared_ptr<query::result>, cache_temperature>&& f_ht) {
                 auto&& [f, ht] = f_ht;
                 tracing::trace(trace_state, "Querying is done");
-                return make_ready_future<rpc::tuple<foreign_ptr<lw_shared_ptr<query::result>>, cache_temperature>>(rpc::tuple(make_foreign(std::move(f)), ht));
+                return make_ready_future<rpc::tuple<foreign_ptr<lw_shared_ptr<query::result>>, cache_temperature, tracing::trace_state_ptr::cache_counter_t>>(rpc::tuple(make_foreign(std::move(f)), ht, get_cache_counter(trace_state)));
             });
         });
     } else {
@@ -4035,7 +4036,7 @@ storage_proxy::query_result_local(schema_ptr s, lw_shared_ptr<query::read_comman
                 [trace_state = std::move(trace_state)] (rpc::tuple<foreign_ptr<lw_shared_ptr<query::result>>, cache_temperature>&& r_ht) {
             auto&& [r, ht] = r_ht;
             tracing::trace(trace_state, "Querying is done");
-            return make_ready_future<rpc::tuple<foreign_ptr<lw_shared_ptr<query::result>>, cache_temperature>>(rpc::tuple(std::move(r), ht));
+            return make_ready_future<rpc::tuple<foreign_ptr<lw_shared_ptr<query::result>>, cache_temperature, tracing::trace_state_ptr::cache_counter_t>>(rpc::tuple(std::move(r), ht, get_cache_counter(trace_state)));
         });
     }
 }

--- a/service/storage_proxy.hh
+++ b/service/storage_proxy.hh
@@ -377,7 +377,7 @@ private:
             const inet_address_vector_replica_set& preferred_endpoints,
             bool& is_bounced_read,
             service_permit permit);
-    future<rpc::tuple<foreign_ptr<lw_shared_ptr<query::result>>, cache_temperature>> query_result_local(schema_ptr, lw_shared_ptr<query::read_command> cmd, const dht::partition_range& pr,
+    future<rpc::tuple<foreign_ptr<lw_shared_ptr<query::result>>, cache_temperature, tracing::trace_state_ptr::cache_counter_t>> query_result_local(schema_ptr, lw_shared_ptr<query::read_command> cmd, const dht::partition_range& pr,
                                                                            query::result_options opts,
                                                                            tracing::trace_state_ptr trace_state,
                                                                            clock_type::time_point timeout);

--- a/tracing/trace_state.cc
+++ b/tracing/trace_state.cc
@@ -355,4 +355,10 @@ void opentelemetry_state::serialize_replicas(bytes& serialized) const {
         serialized += bytes{addr_data, addr_size};
     }
 }
+
+void opentelemetry_state::serialize_cache_counter(bytes& serialized) const {
+    const auto counter = htonl(_cache_counter);
+    const auto *counter_ptr = reinterpret_cast<const int8_t*>(&counter);
+    serialized += bytes{counter_ptr, sizeof(counter)};
+}
 }

--- a/tracing/trace_state.cc
+++ b/tracing/trace_state.cc
@@ -339,7 +339,7 @@ sstring trace_state::raw_value_to_sstring(const cql3::raw_value_view& v, const d
     }
 }
 
-void opentelemetry_state::serialize_replicas(bytes& serialized) const {
+void opentelemetry_state_data::serialize_replicas(bytes& serialized) const {
     const auto size = htonl(_replicas.size());
     const auto *size_ptr = reinterpret_cast<const int8_t*>(&size);
     serialized += bytes{size_ptr, sizeof(size)};
@@ -356,7 +356,7 @@ void opentelemetry_state::serialize_replicas(bytes& serialized) const {
     }
 }
 
-void opentelemetry_state::serialize_cache_counter(bytes& serialized) const {
+void opentelemetry_state_data::serialize_cache_counter(bytes& serialized) const {
     const auto counter = htonl(_cache_counter);
     const auto *counter_ptr = reinterpret_cast<const int8_t*>(&counter);
     serialized += bytes{counter_ptr, sizeof(counter)};

--- a/tracing/trace_state.hh
+++ b/tracing/trace_state.hh
@@ -519,6 +519,7 @@ private:
     cache_counter_t _cache_counter{0};
 
     void serialize_replicas(bytes& serialized) const;
+    void serialize_cache_counter(bytes& serialized) const;
 
 public:
     opentelemetry_state() = default;
@@ -536,6 +537,7 @@ public:
         bytes serialized{};
 
         serialize_replicas(serialized);
+        serialize_cache_counter(serialized);
 
         return serialized;
     }

--- a/tracing/tracing.cc
+++ b/tracing/tracing.cc
@@ -116,11 +116,11 @@ future<> tracing::stop_tracing() {
 }
 
 trace_state_ptr tracing::create_session(trace_type type, trace_state_props_set props, bool opentelemetry_tracing) noexcept {
-    if (!started()) {
-        return opentelemetry_tracing ? make_lw_shared<opentelemetry_state>(nullptr, opentelemetry_tracing) : nullptr;
-    }
-
     try {
+        if (!started()) {
+            return opentelemetry_tracing ? make_lw_shared<opentelemetry_state>(nullptr, opentelemetry_tracing) : nullptr;
+        }
+
         // Don't create a session if its records are likely to be dropped
         if (!may_create_new_session()) {
             return opentelemetry_tracing ? make_lw_shared<opentelemetry_state>(nullptr, opentelemetry_tracing) : nullptr;
@@ -138,18 +138,22 @@ trace_state_ptr tracing::create_session(trace_type type, trace_state_props_set p
 }
 
 trace_state_ptr tracing::create_session(const trace_info& secondary_session_info) noexcept {
-    if (!started()) {
-        return nullptr;
-    }
-
     try {
+        bool opentelemetry_tracing = secondary_session_info.state_props.contains(trace_state_props::opentelemetry);
+        if (!started()) {
+            return opentelemetry_tracing ? make_lw_shared<opentelemetry_state>(nullptr, opentelemetry_tracing) : nullptr;
+        }
+
         // Don't create a session if its records are likely to be dropped
         if (!may_create_new_session(secondary_session_info.session_id)) {
-            return nullptr;
+            return opentelemetry_tracing ? make_lw_shared<opentelemetry_state>(nullptr, opentelemetry_tracing) : nullptr;
         }
 
         ++_active_sessions;
-        return make_lw_shared<trace_state>(secondary_session_info);
+        if (secondary_session_info.state_props.contains(trace_state_props::classic)) {
+            return make_lw_shared<opentelemetry_state>(make_lw_shared<trace_state>(secondary_session_info), opentelemetry_tracing);
+        }
+        return make_lw_shared<opentelemetry_state>(nullptr, opentelemetry_tracing);
     } catch (...) {
         // return an uninitialized state in case of any error (OOM?)
         return nullptr;

--- a/tracing/tracing.cc
+++ b/tracing/tracing.cc
@@ -141,19 +141,19 @@ trace_state_ptr tracing::create_session(const trace_info& secondary_session_info
     try {
         bool opentelemetry_tracing = secondary_session_info.state_props.contains(trace_state_props::opentelemetry);
         if (!started()) {
-            return opentelemetry_tracing ? make_lw_shared<opentelemetry_state>(nullptr, opentelemetry_tracing) : nullptr;
+            return opentelemetry_tracing ? make_lw_shared<opentelemetry_state>(nullptr, secondary_session_info.otel_data) : nullptr;
         }
 
         // Don't create a session if its records are likely to be dropped
         if (!may_create_new_session(secondary_session_info.session_id)) {
-            return opentelemetry_tracing ? make_lw_shared<opentelemetry_state>(nullptr, opentelemetry_tracing) : nullptr;
+            return opentelemetry_tracing ? make_lw_shared<opentelemetry_state>(nullptr, secondary_session_info.otel_data) : nullptr;
         }
 
         ++_active_sessions;
         if (secondary_session_info.state_props.contains(trace_state_props::classic)) {
-            return make_lw_shared<opentelemetry_state>(make_lw_shared<trace_state>(secondary_session_info), opentelemetry_tracing);
+            return make_lw_shared<opentelemetry_state>(make_lw_shared<trace_state>(secondary_session_info), secondary_session_info.otel_data);
         }
-        return make_lw_shared<opentelemetry_state>(nullptr, opentelemetry_tracing);
+        return make_lw_shared<opentelemetry_state>(nullptr, secondary_session_info.otel_data);
     } catch (...) {
         // return an uninitialized state in case of any error (OOM?)
         return nullptr;

--- a/tracing/tracing.hh
+++ b/tracing/tracing.hh
@@ -141,6 +141,8 @@ using trace_state_props_set = enum_set<super_enum<trace_state_props,
     trace_state_props::opentelemetry,
     trace_state_props::classic>>;
 
+class opentelemetry_state_data;
+
 class trace_info {
 public:
     utils::UUID session_id;
@@ -150,6 +152,7 @@ public:
     uint32_t slow_query_threshold_us; // in microseconds
     uint32_t slow_query_ttl_sec; // in seconds
     span_id parent_id;
+    std::shared_ptr<seastar::sharded<opentelemetry_state_data>> otel_data;
 
 public:
     trace_info(utils::UUID sid, trace_type t, bool w_o_c, trace_state_props_set s_p, uint32_t slow_query_threshold, uint32_t slow_query_ttl, span_id p_id)
@@ -164,7 +167,9 @@ public:
         state_props.set_if<trace_state_props::write_on_close>(write_on_close);
     }
 
-    trace_info(trace_state_props_set s_p) : state_props(s_p) {}
+    trace_info(trace_state_props_set s_p, std::shared_ptr<seastar::sharded<opentelemetry_state_data>> otel_data)
+        : state_props(s_p), otel_data(otel_data)
+    {}
 };
 
 struct one_session_records;

--- a/tracing/tracing.hh
+++ b/tracing/tracing.hh
@@ -129,7 +129,7 @@ std::ostream& operator<<(std::ostream& os, const span_id& id);
 //
 // Otherwise this may break IDL's backward compatibility.
 enum class trace_state_props {
-    write_on_close, primary, log_slow_query, full_tracing, ignore_events
+    write_on_close, primary, log_slow_query, full_tracing, ignore_events, opentelemetry, classic
 };
 
 using trace_state_props_set = enum_set<super_enum<trace_state_props,
@@ -137,7 +137,9 @@ using trace_state_props_set = enum_set<super_enum<trace_state_props,
     trace_state_props::primary,
     trace_state_props::log_slow_query,
     trace_state_props::full_tracing,
-    trace_state_props::ignore_events>>;
+    trace_state_props::ignore_events,
+    trace_state_props::opentelemetry,
+    trace_state_props::classic>>;
 
 class trace_info {
 public:
@@ -161,6 +163,8 @@ public:
     {
         state_props.set_if<trace_state_props::write_on_close>(write_on_close);
     }
+
+    trace_info(trace_state_props_set s_p) : state_props(s_p) {}
 };
 
 struct one_session_records;


### PR DESCRIPTION
The PR introduces tracing information about a number of partitions read from the cache.
The opentelemetry_state is extended to store that counter.